### PR TITLE
UX polish: dark mode, sticky terminal nav, typed tagline, micro-interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // Set the theme before first paint to avoid a flash of the wrong mode.
+      (function () {
+        try {
+          var t = localStorage.getItem('theme');
+          if (t !== 'dark' && t !== 'light') {
+            t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          document.documentElement.dataset.theme = t;
+        } catch (e) {
+          document.documentElement.dataset.theme = 'light';
+        }
+      })();
+    </script>
     <title>Sharath Chandra Raparthy — Research Engineer, Google DeepMind</title>
     <meta name="author" content="Sharath Chandra Raparthy" />
     <meta

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import App from './App.tsx';
 import { newsItems } from './data/news.tsx';
 import { papers } from './data/papers.tsx';
@@ -54,6 +54,24 @@ describe('App', () => {
       'src',
       '/images/rainbow-teaming.png',
     );
+  });
+
+  it('renders header navigation to all sections', () => {
+    const { section } = renderApp();
+    const nav = section('.header-nav');
+    expect(nav.getByRole('link', { name: 'about' })).toHaveAttribute('href', '#about');
+    expect(nav.getByRole('link', { name: 'news' })).toHaveAttribute('href', '#news');
+    expect(nav.getByRole('link', { name: 'research' })).toHaveAttribute('href', '#research');
+  });
+
+  it('toggles between dark and light theme', () => {
+    const { section } = renderApp();
+    const initial = document.documentElement.dataset.theme;
+    const toggle = section('.header-nav').getByRole('button', { name: /switch to/i });
+    fireEvent.click(toggle);
+    expect(document.documentElement.dataset.theme).not.toBe(initial);
+    fireEvent.click(toggle);
+    expect(document.documentElement.dataset.theme).toBe(initial);
   });
 
   it('external social links open safely in a new tab', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,21 @@
+import Header from './components/Header.tsx';
 import Hero from './components/Hero.tsx';
 import NewsSection from './components/NewsSection.tsx';
 import ResearchSection from './components/ResearchSection.tsx';
 import Footer from './components/Footer.tsx';
+import BackToTop from './components/BackToTop.tsx';
 
 export default function App() {
   return (
-    <div className="site-container">
-      <Hero />
-      <NewsSection />
-      <ResearchSection />
-      <Footer />
-    </div>
+    <>
+      <Header />
+      <div className="site-container" id="top">
+        <Hero />
+        <NewsSection />
+        <ResearchSection />
+        <Footer />
+      </div>
+      <BackToTop />
+    </>
   );
 }

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function BackToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      className={`back-to-top${visible ? ' visible' : ''}`}
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      aria-label="Back to top"
+      tabIndex={visible ? 0 : -1}
+    >
+      <span aria-hidden="true">cd ~</span>
+    </button>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,14 @@ export default function Footer() {
 
   return (
     <footer className="site-footer" ref={footerRef}>
-      &copy; {new Date().getFullYear()} Sharath Chandra Raparthy
+      <div className="footer-line">
+        <span className="footer-prompt">$</span> echo &quot;&copy; {new Date().getFullYear()}{' '}
+        Sharath Chandra Raparthy&quot;
+      </div>
+      <div className="footer-meta">
+        Built with React + Vite ·{' '}
+        <a href="https://github.com/SharathRaparthy/SharathRaparthy.github.io">source</a>
+      </div>
     </footer>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,45 @@
+import { useTheme } from '../hooks/useTheme.ts';
+
+const navLinks = [
+  { label: 'about', href: '#about' },
+  { label: 'news', href: '#news' },
+  { label: 'research', href: '#research' },
+];
+
+export default function Header() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <header className="site-header">
+      <div className="site-header-inner">
+        <a className="header-logo" href="#top" aria-label="Back to top">
+          <span className="header-prompt">~/</span>sharath
+        </a>
+        <nav className="header-nav" aria-label="Site sections">
+          {navLinks.map(({ label, href }) => (
+            <a key={label} href={href} className="header-nav-link">
+              {label}
+            </a>
+          ))}
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            {theme === 'dark' ? (
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 18a6 6 0 100-12 6 6 0 000 12zM12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+              </svg>
+            )}
+          </button>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,10 +1,21 @@
 import SocialLinks from './SocialLinks.tsx';
+import { useTypewriter } from '../hooks/useTypewriter.ts';
+
+const TAGLINE = 'research = ["LLM reasoning", "open-endedness", "in-context RL"]';
 
 export default function Hero() {
+  const { typed, done } = useTypewriter(TAGLINE);
+
   return (
-    <section className="hero-section">
+    <section className="hero-section" id="about">
       <div className="hero-text">
         <h1 className="hero-name">Sharath Chandra Raparthy</h1>
+        <p className="hero-tagline" aria-label={TAGLINE}>
+          <span aria-hidden="true">
+            {typed}
+            <span className={`typing-caret${done ? ' done' : ''}`} />
+          </span>
+        </p>
 
         <p>
           I am a Research Engineer at <a href="https://deepmind.google/">Google DeepMind</a>,

--- a/src/components/NewsSection.tsx
+++ b/src/components/NewsSection.tsx
@@ -5,7 +5,7 @@ export default function NewsSection() {
   const sectionRef = useScrollReveal<HTMLElement>();
 
   return (
-    <section className="news-section" ref={sectionRef}>
+    <section className="news-section" id="news" ref={sectionRef}>
       <h2>News</h2>
       <div className="news-fade" role="region" aria-label="News updates" tabIndex={0}>
         <div className="news-container">

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -6,7 +6,7 @@ export default function ResearchSection() {
   const headingRef = useScrollReveal<HTMLHeadingElement>();
 
   return (
-    <section className="research-section">
+    <section className="research-section" id="research">
       <h2 ref={headingRef}>Research</h2>
       {papers.map((paper) => (
         <PaperCard paper={paper} key={paper.title} />

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+function getInitialTheme(): Theme {
+  // The inline script in index.html sets this before first paint.
+  const fromDom = document.documentElement.dataset.theme;
+  if (fromDom === 'dark' || fromDom === 'light') return fromDom;
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark' || stored === 'light') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return { theme, toggleTheme };
+}

--- a/src/hooks/useTypewriter.ts
+++ b/src/hooks/useTypewriter.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Types out `text` character by character. Renders the full text immediately
+ * when the user prefers reduced motion.
+ */
+export function useTypewriter(text: string, speedMs = 35, startDelayMs = 400) {
+  const reduceMotion =
+    typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const [length, setLength] = useState(() => (reduceMotion ? text.length : 0));
+
+  useEffect(() => {
+    if (reduceMotion) return;
+
+    let i = 0;
+    let interval: ReturnType<typeof setInterval> | undefined;
+    const start = setTimeout(() => {
+      interval = setInterval(() => {
+        i += 1;
+        setLength(i);
+        if (i >= text.length) clearInterval(interval);
+      }, speedMs);
+    }, startDelayMs);
+
+    return () => {
+      clearTimeout(start);
+      if (interval) clearInterval(interval);
+    };
+  }, [text, speedMs, startDelayMs, reduceMotion]);
+
+  return { typed: text.slice(0, length), done: length >= text.length };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -59,6 +59,43 @@
   --duration-fast: 150ms;
   --duration-normal: 250ms;
   --duration-slow: 400ms;
+
+  /* Theme-dependent extras */
+  --grid-line: rgba(0, 0, 0, 0.04);
+  --photo-ring: #ffffff;
+  --header-bg: rgba(255, 255, 255, 0.82);
+
+  color-scheme: light;
+}
+
+/* ── Dark theme ──────────────────────────────────────── */
+:root[data-theme='dark'] {
+  --bg-primary: #0d1117;
+  --bg-secondary: #11161d;
+  --bg-card: #161c24;
+  --bg-card-hover: #1b222c;
+  --border: #2d3743;
+  --border-subtle: #222a34;
+
+  --text-primary: #e6edf3;
+  --text-secondary: #b7c0ca;
+  --text-muted: #8b949e;
+  --text-dim: #6e7681;
+
+  --green: #3fb950;
+  --green-dim: rgba(63, 185, 80, 0.12);
+  --blue: #58a6ff;
+  --blue-dim: rgba(88, 166, 255, 0.1);
+  --purple: #a371f7;
+  --amber: #e3b341;
+  --red: #f85149;
+  --cyan: #2dd4a8;
+
+  --grid-line: rgba(255, 255, 255, 0.045);
+  --photo-ring: #0d1117;
+  --header-bg: rgba(13, 17, 23, 0.82);
+
+  color-scheme: dark;
 }
 /* ── Reset & Base ────────────────────────────────────── */
 *,
@@ -71,6 +108,7 @@
 html {
   font-size: 16px;
   scroll-behavior: smooth;
+  scroll-padding-top: 72px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -83,6 +121,9 @@ body {
   background-color: var(--bg-primary);
   min-height: 100vh;
   position: relative;
+  transition:
+    background-color var(--duration-normal) var(--ease),
+    color var(--duration-normal) var(--ease);
 }
 
 /* ── Animated gradient border at top ─────────────────── */
@@ -105,8 +146,8 @@ body::after {
   position: fixed;
   inset: 0;
   background-image:
-    linear-gradient(rgba(0, 0, 0, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 0, 0, 0.04) 1px, transparent 1px);
+    linear-gradient(var(--grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
   background-size: 60px 60px;
   pointer-events: none;
   z-index: 0;
@@ -204,14 +245,27 @@ h2::after {
   font-weight: 400;
   opacity: 0.8;
 }
-/* Blinking cursor after name */
-.hero-name::after {
-  content: '█';
-  color: var(--green);
-  font-weight: 400;
-  animation: cursorBlink 1s step-end infinite;
+/* Typed tagline under the name (carries the live cursor) */
+.hero-tagline {
+  font-family: var(--font-code);
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+  min-height: 1.7em;
+  letter-spacing: -0.01em;
+}
+
+.typing-caret {
+  display: inline-block;
+  width: 7px;
+  height: 1.05em;
   margin-left: 2px;
-  font-size: 24px;
+  background: var(--green);
+  vertical-align: text-bottom;
+}
+
+.typing-caret.done {
+  animation: cursorBlink 1s step-end infinite;
 }
 .hero-text p {
   color: var(--text-secondary);
@@ -266,7 +320,7 @@ h2::after {
   object-fit: cover;
   object-position: 50% 30%;
   border-radius: 50%;
-  border: 3px solid #ffffff;
+  border: 3px solid var(--photo-ring);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: transform var(--duration-normal) var(--ease-spring);
 }
@@ -733,4 +787,163 @@ h2::after {
     opacity: 1;
     transform: none;
   }
+}
+
+/* ████████████████████████████████████████████████████████
+   STICKY HEADER
+   ████████████████████████████████████████████████████████ */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--header-bg);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background-color var(--duration-normal) var(--ease);
+}
+
+.site-header-inner {
+  max-width: var(--container-width);
+  margin: 0 auto;
+  padding: 0.6rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-logo {
+  font-family: var(--font-code);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.header-logo:hover {
+  color: var(--green);
+}
+
+.header-prompt {
+  color: var(--green);
+}
+
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+}
+
+.header-nav-link {
+  font-family: var(--font-code);
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.header-nav-link::before {
+  content: '#';
+  color: var(--text-dim);
+  opacity: 0.7;
+}
+
+.header-nav-link:hover {
+  color: var(--green);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--duration-normal) var(--ease);
+}
+
+.theme-toggle:hover {
+  border-color: var(--green);
+  color: var(--green);
+  background: var(--green-dim);
+  transform: translateY(-1px);
+}
+
+.theme-toggle svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* ████████████████████████████████████████████████████████
+   BACK TO TOP
+   ████████████████████████████████████████████████████████ */
+.back-to-top {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 90;
+  font-family: var(--font-code);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 14px;
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  transition: all var(--duration-normal) var(--ease);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+.back-to-top:hover {
+  color: var(--green);
+  border-color: var(--green);
+  background: var(--green-dim);
+  transform: translateY(-2px);
+}
+
+/* ── Footer extras ───────────────────────────────────── */
+.footer-line {
+  margin-bottom: 0.35rem;
+}
+
+.footer-prompt {
+  color: var(--green);
+}
+
+.footer-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.footer-meta a {
+  color: var(--text-muted);
+}
+
+.footer-meta a:hover {
+  color: var(--green);
+}
+
+/* ── Keyboard focus ──────────────────────────────────── */
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+  border-radius: 4px;
 }

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -21,3 +21,18 @@ class MockIntersectionObserver implements IntersectionObserver {
 
 globalThis.IntersectionObserver =
   MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+// jsdom does not implement matchMedia (used by theme + typewriter hooks).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Summary

Aesthetic & experience upgrade, keeping the "neural terminal" identity:

- **Dark/light mode** — defaults to system preference, persists in localStorage, pre-paint init script so there's no flash of the wrong theme; sun/moon toggle in the header. Dark palette is GitHub-dark-inspired with vivid accents.
- **Sticky translucent nav** — terminal-style `~/sharath` logo, `#about / #news / #research` anchors with smooth scrolling.
- **Typed hero tagline** — `research = ["LLM reasoning", "open-endedness", "in-context RL"]` typewrites in under the name; the blinking cursor moved from the h1 to this line. Renders instantly under `prefers-reduced-motion`.
- **`cd ~` back-to-top button** after scrolling 600px.
- **Footer** echoes a shell line plus build info and source link.
- **Keyboard focus-visible outlines** throughout.

## Verification

- 7/7 tests (including new nav + theme-toggle tests)
- lint / format / strict build green
- Production bundle smoke-rendered: header anchors, theme attribute, tagline, back-to-top all present

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_