### PR TITLE
Bulletproof content visibility + remote debug overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,5 +87,36 @@
     </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      // Visit /?debug=1 to overlay render diagnostics on the page.
+      if (location.search.indexOf('debug') !== -1) {
+        window.__errs = [];
+        window.addEventListener('error', function (e) {
+          window.__errs.push((e.message || String(e)).slice(0, 120));
+        });
+        setTimeout(function () {
+          var root = document.getElementById('root');
+          var h1 = document.querySelector('h1');
+          var hero = document.querySelector('.hero-section');
+          var box = document.createElement('pre');
+          box.style.cssText =
+            'position:fixed;left:8px;bottom:8px;z-index:2147483647;background:#000;color:#0f0;' +
+            'font:11px/1.5 monospace;padding:10px 12px;border-radius:8px;max-width:92vw;' +
+            'white-space:pre-wrap;opacity:1;transform:none;';
+          box.textContent = [
+            'root children: ' + (root ? root.children.length : 'NO #root'),
+            'h1 text: ' + (h1 ? h1.textContent.slice(0, 40) : 'NONE'),
+            'hero opacity: ' + (hero ? getComputedStyle(hero).opacity : '-'),
+            'hero display: ' + (hero ? getComputedStyle(hero).display : '-'),
+            'hydrated: ' + (window.__APP_LOADED__ === true),
+            'theme: ' + document.documentElement.getAttribute('data-theme'),
+            'body bg: ' + getComputedStyle(document.body).backgroundColor,
+            'js errors: ' + (window.__errs.join(' | ') || 'none'),
+            'ua: ' + navigator.userAgent.slice(0, 90),
+          ].join('\n');
+          document.body.appendChild(box);
+        }, 2500);
+      }
+    </script>
   </body>
 </html>

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -26,7 +26,14 @@ export function useScrollReveal<T extends HTMLElement>() {
     );
 
     observer.observe(el);
-    return () => observer.disconnect();
+
+    // Failsafe: never leave content hidden if the observer misbehaves.
+    const failsafe = setTimeout(() => el.classList.add('revealed'), 1500);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(failsafe);
+    };
   }, []);
 
   return ref;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,3 +17,11 @@ if (container.hasChildNodes()) {
 } else {
   createRoot(container).render(app);
 }
+
+declare global {
+  interface Window {
+    __APP_LOADED__?: boolean;
+    __errs?: string[];
+  }
+}
+window.__APP_LOADED__ = true;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -169,7 +169,9 @@ h2::after {
   gap: 3.5rem;
   margin-bottom: var(--section-gap);
   padding-top: 1.5rem;
-  animation: rise 0.7s var(--ease) both;
+  /* No fill mode on purpose: if animations are blocked or paused by the
+     browser, the element must rest at its natural (visible) styles. */
+  animation: rise 0.7s var(--ease);
 }
 
 .hero-text {
@@ -248,7 +250,7 @@ h2::after {
   width: 200px;
   height: 200px;
   position: relative;
-  animation: rise 0.9s var(--ease) 0.15s both;
+  animation: rise 0.9s var(--ease);
 }
 
 .hero-photo::before {


### PR DESCRIPTION
Hardens rendering so content can never be hidden by CSS state:

- Entry animations drop their fill modes — if the browser pauses/blocks CSS animations, elements rest at their natural visible styles instead of opacity 0
- Scroll-reveal gains a 1.5 s failsafe reveal in case IntersectionObserver never fires
- `/?debug=1` overlays live render diagnostics (root children count, hero computed opacity/display, hydration flag, theme, captured JS errors, user agent) for remote debugging

7/7 tests, lint, build + prerender green.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_