### PR TITLE
Inline blank-page watchdog + render fresh instead of hydrating

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,22 @@
       </p>
     </noscript>
     <div id="root"></div>
+    <script>
+      // Inline watchdog: runs even if the app bundle fails or crashes.
+      // If anything leaves the root empty after boot (hydration crash,
+      // DOM-mutating extension, missing bundle), restore the prerendered HTML.
+      (function () {
+        var root = document.getElementById('root');
+        var snapshot = root ? root.innerHTML : '';
+        if (!snapshot) return;
+        setTimeout(function () {
+          if (root.childElementCount === 0) {
+            root.innerHTML = snapshot;
+            if (window.__errs) window.__errs.push('inline watchdog restored content');
+          }
+        }, 2000);
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
     <script>
       // Visit /?debug=1 to overlay render diagnostics on the page.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from 'react';
-import { createRoot, hydrateRoot } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './styles/global.css';
 
@@ -10,41 +10,17 @@ declare global {
   }
 }
 
+// Deliberately NOT hydrating: browser extensions and auto-translators mutate
+// the prerendered DOM before React boots, and hydration mismatches can crash
+// fatally (unmounting everything — observed in production as a blank page).
+// A fresh client render is immune: React owns a clean tree, and the
+// prerendered HTML still serves SEO, no-JS visitors, and first paint.
 const container = document.getElementById('root')!;
-// Keep a copy of the prerendered markup so it can be restored if anything
-// (a hydration crash, an extension mutating the DOM) empties the root.
-const staticHtml = container.innerHTML;
-
-const app = (
+container.innerHTML = '';
+createRoot(container).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 );
-
-function clientRender() {
-  container.innerHTML = '';
-  createRoot(container).render(app);
-}
-
-if (container.hasChildNodes()) {
-  try {
-    hydrateRoot(container, app);
-  } catch {
-    clientRender();
-  }
-} else {
-  // Dev server serves an empty root.
-  clientRender();
-}
-
-// Watchdog: content must never disappear. If the root is empty shortly after
-// boot (e.g. hydration was corrupted by a translation/dark-mode extension and
-// React unmounted), restore the static prerendered HTML.
-setTimeout(() => {
-  if (container.childElementCount === 0 && staticHtml) {
-    window.__errs?.push('watchdog: root was empty, restored static HTML');
-    container.innerHTML = staticHtml;
-  }
-}, 1800);
 
 window.__APP_LOADED__ = true;


### PR DESCRIPTION
Final hardening for the recurring blank page:

- **Inline watchdog in `index.html`** — independent of the app bundle. If `#root` is empty 2 s after parse (bundle 404, boot crash, extension interference), the prerendered markup is restored in place.
- **No more hydration** — `main.tsx` client-renders a fresh React tree instead of hydrating the prerendered DOM. DOM mutations made by extensions/auto-translate before boot (the diagnosed cause: `root children: 0` on the live site while the served HTML verifiably contained full content) can no longer produce fatal mismatch crashes. The prerendered HTML still provides SEO, no-JS support, and instant first paint.

Verified in simulation: (A) bundle never runs → content remains; (B) root wiped after boot → watchdog restores all content; (C) normal boot → clean render, 0 errors. Tests/lint/build green.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_