### PR TITLE
Disable legacy branch deploys: switch Pages build type to workflow

### DIFF
--- a/.github/workflows/fix-pages.yml
+++ b/.github/workflows/fix-pages.yml
@@ -1,0 +1,28 @@
+name: Fix Pages build type
+
+on:
+  workflow_dispatch:
+
+permissions:
+  pages: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Switch Pages source to GitHub Actions
+        run: |
+          echo "--- current config ---"
+          curl -sS -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/pages
+          echo "--- setting build_type=workflow ---"
+          curl -sS -X PUT \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/pages \
+            -d '{"build_type":"workflow"}' -w "\nHTTP %{http_code}\n"
+          echo "--- config after ---"
+          curl -sS -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/pages


### PR DESCRIPTION
## Root cause of every blank page — confirmed with the probe

The live-site probe (run from a GitHub Actions runner) showed the served homepage is the **raw source `index.html`** — empty `<div id="root">` and `<script src="/src/site.ts">` — not the built site. The legacy `pages-build-deployment` (deploy-from-branch) workflow is still active and has re-deployed the raw repo **after every merge** (09:11, 08:41, 07:54, 07:45 UTC runs), overwriting each Actions deployment. This is why the site rendered exactly once (after a manual redeploy with no accompanying push) and went blank after every merge.

This adds a `workflow_dispatch` job that flips the Pages `build_type` to `workflow` via the API, disabling the legacy branch builds permanently. Fallback if the token lacks permission: one click in **Settings → Pages → Source → "GitHub Actions"**.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_