### PR TITLE
Bento: dark-first card-grid redesign (Space Grotesk + lime)

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,600;1,9..144,500;1,9..144,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap"
     />
   </head>
   <body>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,49 +1,65 @@
 import SocialLinks from './SocialLinks.tsx';
+import { papers } from '../data/papers.tsx';
+import { newsItems } from '../data/news.tsx';
 
 export default function Hero() {
   return (
     <section className="hero-section" id="about">
-      <div className="hero-text">
-        <p className="hero-eyebrow">
-          Open-endedness <span aria-hidden="true">·</span> LLM reasoning{' '}
-          <span aria-hidden="true">·</span> In-context RL
-        </p>
+      <div className="bento-card hero-text">
+        <div className="topic-chips">
+          <span className="topic-chip">Open-endedness</span>
+          <span className="topic-chip">LLM reasoning</span>
+          <span className="topic-chip">In-context RL</span>
+        </div>
         <h1 className="hero-name">Sharath Chandra Raparthy</h1>
         <p className="hero-role">
-          Research Engineer at <a href="https://deepmind.google/">Google DeepMind</a>
+          Research Engineer at <a href="https://deepmind.google/">Google DeepMind</a> — building
+          open-ended systems that keep inventing, learning, and surprising us.
         </p>
 
-        <p>
-          I work on open-endedness — building systems that keep inventing, learning, and surprising
-          us. Previously, I was a Member of Technical Staff at{' '}
-          <a href="https://www.reka.ai/">Reka AI</a>, building general-purpose multimodal agents,
-          and an AI Resident at <a href="https://ai.meta.com/">FAIR (Meta)</a>, where I was a core
-          contributor to <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> — shipping tool-use
-          and mathematical reasoning — and co-led{' '}
-          <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>, a method for
-          stress-testing and improving LLM robustness at scale.
+        <p className="hero-bio">
+          Previously a Member of Technical Staff at <a href="https://www.reka.ai/">Reka AI</a>{' '}
+          building general-purpose multimodal agents, and an AI Resident at{' '}
+          <a href="https://ai.meta.com/">FAIR (Meta)</a> — core contributor to{' '}
+          <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> (tool-use and mathematical
+          reasoning) and co-lead of <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>.
         </p>
 
-        <p>
-          I hold a Master&apos;s (with thesis) from <a href="https://mila.quebec/en/">Mila</a>,
-          advised by <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>, and spent
-          time at <a href="https://www.recursion.com">Recursion</a> applying GFlowNets to drug
-          discovery. Off the clock: long runs, cooking, books, and a camera.
+        <p className="hero-bio">
+          Master&apos;s (with thesis) from <a href="https://mila.quebec/en/">Mila</a>, advised by{' '}
+          <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>; research internship at{' '}
+          <a href="https://www.recursion.com">Recursion</a> applying GFlowNets to drug discovery.
+          Off the clock: long runs, cooking, books, a camera.
         </p>
 
         <SocialLinks />
       </div>
 
-      <figure className="hero-photo">
-        <img
-          src="/images/sharath_sf.jpg"
-          alt="Sharath Chandra Raparthy"
-          width={480}
-          height={480}
-          fetchPriority="high"
-        />
-        <figcaption className="hero-photo-caption">Google DeepMind — Open-Endedness</figcaption>
-      </figure>
+      <div className="hero-side">
+        <div className="bento-card hero-photo">
+          <img
+            src="/images/sharath_sf.jpg"
+            alt="Sharath Chandra Raparthy"
+            width={480}
+            height={480}
+            fetchPriority="high"
+          />
+        </div>
+        <div className="bento-card hero-stats">
+          <div className="stat">
+            <span className="stat-num">{papers.length}</span>
+            <span className="stat-label">Publications</span>
+          </div>
+          <div className="stat">
+            <span className="stat-num">{newsItems.length}</span>
+            <span className="stat-label">Updates</span>
+          </div>
+          <div className="stat">
+            <span className="stat-num">Llama 3</span>
+            <span className="stat-label">Core contributor</span>
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -5,9 +5,11 @@ export default function ResearchSection() {
   return (
     <section className="research-section" id="research">
       <h2>Research</h2>
-      {papers.map((paper) => (
-        <PaperCard paper={paper} key={paper.title} />
-      ))}
+      <div className="research-grid">
+        {papers.map((paper) => (
+          <PaperCard paper={paper} key={paper.title} />
+        ))}
+      </div>
     </section>
   );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,54 +1,61 @@
 /* ==========================================================
-   ATELIER — Sharath Chandra Raparthy
-   Chic editorial: ivory paper, ink, bordeaux. Oversized serif,
-   numbered sections, magazine-index research list.
+   BENTO — Sharath Chandra Raparthy
+   Dark-first app aesthetic: card grid, Space Grotesk,
+   near-black surfaces, electric lime accent.
    ========================================================== */
 
-/* Fonts via <link> in index.html: Fraunces, Inter, JetBrains Mono. */
+/* Fonts via <link> in index.html: Space Grotesk, Inter. */
 
 /* ── Tokens ──────────────────────────────────────────── */
 :root {
-  --bg: #f6f4ee;
-  --bg-elevated: #fdfcf8;
-  --border: rgba(26, 23, 19, 0.14);
-  --border-soft: rgba(26, 23, 19, 0.08);
+  --bg: #f4f5f4;
+  --card: #ffffff;
+  --card-2: #ececea;
+  --border: rgba(18, 20, 17, 0.1);
+  --border-strong: rgba(18, 20, 17, 0.18);
 
-  --text: #1a1713;
-  --text-2: #4c4740;
-  --text-3: #8e867a;
+  --text: #15171a;
+  --text-2: #4d5158;
+  --text-3: #8a8f97;
 
-  --accent: #8e2f3c;
-  --accent-strong: #6e2330;
-  --accent-soft: rgba(142, 47, 60, 0.08);
+  --accent: #4d7c0f;
+  --accent-bright: #84cc16;
+  --accent-soft: rgba(132, 204, 22, 0.14);
+  --accent-ink: #101203;
 
-  --font-display: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-display: 'Space Grotesk', 'Inter', -apple-system, sans-serif;
   --font-body:
     'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
 
-  --container: 1060px;
-  --section-gap: 7rem;
+  --container: 1100px;
+  --section-gap: 5rem;
+
+  --r-lg: 24px;
+  --r-md: 16px;
+  --r-sm: 10px;
 
   --ease: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  --fast: 160ms;
-  --normal: 300ms;
+  --fast: 150ms;
+  --normal: 280ms;
 
   color-scheme: light;
 }
 
 :root[data-theme='dark'] {
-  --bg: #131110;
-  --bg-elevated: #1b1816;
-  --border: rgba(236, 230, 221, 0.16);
-  --border-soft: rgba(236, 230, 221, 0.08);
+  --bg: #0a0b0d;
+  --card: #131519;
+  --card-2: #1a1d22;
+  --border: rgba(244, 246, 248, 0.08);
+  --border-strong: rgba(244, 246, 248, 0.16);
 
-  --text: #ece6dd;
-  --text-2: #b5ada1;
-  --text-3: #766e62;
+  --text: #f2f4f6;
+  --text-2: #a3a9b3;
+  --text-3: #686e79;
 
-  --accent: #d4b483;
-  --accent-strong: #e7cda1;
-  --accent-soft: rgba(212, 180, 131, 0.1);
+  --accent: #c9f24e;
+  --accent-bright: #c9f24e;
+  --accent-soft: rgba(201, 242, 78, 0.1);
+  --accent-ink: #0c0e04;
 
   color-scheme: dark;
 }
@@ -65,15 +72,15 @@
 html {
   font-size: 16px;
   scroll-behavior: smooth;
-  scroll-padding-top: 84px;
+  scroll-padding-top: 96px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 body {
   font-family: var(--font-body);
-  font-size: 16px;
-  line-height: 1.7;
+  font-size: 15.5px;
+  line-height: 1.65;
   color: var(--text);
   background-color: var(--bg);
   min-height: 100vh;
@@ -89,7 +96,7 @@ a {
 }
 
 a:hover {
-  color: var(--accent-strong);
+  color: var(--text);
 }
 
 ::selection {
@@ -100,230 +107,242 @@ a:hover {
 .site-container {
   max-width: var(--container);
   margin: 0 auto;
-  padding: 0 2.5rem 2rem;
+  padding: 6.5rem 1.5rem 2rem;
 }
 
-/* ── Numbered section headings ───────────────────────── */
+/* ── Section headings ────────────────────────────────── */
 h2 {
   font-family: var(--font-display);
-  font-style: italic;
-  font-size: 2rem;
-  font-weight: 500;
-  letter-spacing: -0.01em;
+  font-size: 1.9rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-transform: lowercase;
   color: var(--text);
-  margin-bottom: 2.25rem;
+  margin-bottom: 1.6rem;
   display: flex;
-  align-items: baseline;
-  gap: 1.1rem;
+  align-items: center;
+  gap: 0.8rem;
 }
 
 h2::before {
-  font-family: var(--font-mono);
-  font-style: normal;
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.18em;
-  color: var(--accent);
-}
-
-.news-section h2::before {
-  content: '01 /';
-}
-
-.research-section h2::before {
-  content: '02 /';
-}
-
-h2::after {
   content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--border);
-  align-self: center;
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+  background: var(--accent-bright);
+  flex-shrink: 0;
 }
 
 /* ████████████████████████████████████████████████████████
-   HERO — full-height editorial spread
+   BENTO CARDS
+   ████████████████████████████████████████████████████████ */
+.bento-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  transition:
+    border-color var(--normal) var(--ease),
+    transform var(--normal) var(--ease),
+    background-color var(--normal) var(--ease);
+}
+
+/* ████████████████████████████████████████████████████████
+   HERO — bento grid
    ████████████████████████████████████████████████████████ */
 .hero-section {
   display: grid;
-  grid-template-columns: 1.45fr 1fr;
-  gap: 4.5rem;
-  align-items: center;
-  min-height: calc(100svh - 64px);
-  padding: 4rem 0 5rem;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 1.1rem;
   margin-bottom: var(--section-gap);
-  border-bottom: 1px solid var(--border);
-  animation: rise 0.8s var(--ease);
+  animation: pop 0.6s var(--ease);
 }
 
-.hero-eyebrow {
-  font-family: var(--font-mono);
-  font-size: 11px;
+.hero-side {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: 1.1rem;
+  min-width: 0;
+}
+
+.hero-text {
+  padding: 2.5rem;
+}
+
+.topic-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 1.6rem;
+}
+
+.topic-chip {
+  font-family: var(--font-display);
+  font-size: 12px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  color: var(--text-3);
-  margin-bottom: 1.75rem;
-}
-
-.hero-eyebrow span {
+  letter-spacing: 0.01em;
   color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 4px 13px;
 }
 
 .hero-name {
   font-family: var(--font-display);
-  font-size: clamp(3rem, 7.2vw, 5.2rem);
-  font-weight: 500;
-  letter-spacing: -0.025em;
-  line-height: 1.02;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
   color: var(--text);
-  margin-bottom: 1.5rem;
-  max-width: 11ch;
+  margin-bottom: 1.1rem;
 }
 
 .hero-role {
   font-family: var(--font-display);
-  font-style: italic;
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.5;
   color: var(--text-2);
-  margin-bottom: 2rem;
+  margin-bottom: 1.4rem;
+  max-width: 34rem;
 }
 
 .hero-role a {
   color: var(--text);
-  border-bottom: 1px solid var(--accent);
-  padding-bottom: 2px;
+  box-shadow: inset 0 -2px 0 var(--accent-bright);
 }
 
 .hero-role a:hover {
   color: var(--accent);
 }
 
-.hero-text p:not(.hero-eyebrow):not(.hero-role) {
+.hero-bio {
+  font-size: 14.5px;
+  line-height: 1.75;
   color: var(--text-2);
-  font-size: 15px;
-  line-height: 1.8;
-  margin-bottom: 1rem;
-  max-width: 56ch;
+  margin-bottom: 0.9rem;
+  max-width: 36rem;
 }
 
-.hero-text p a {
+.hero-bio a {
   color: var(--text);
   font-weight: 500;
-  text-decoration: underline;
-  text-decoration-color: var(--border);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3.5px;
-  transition:
-    color var(--fast) var(--ease),
-    text-decoration-color var(--fast) var(--ease);
+  box-shadow: inset 0 -1px 0 var(--border-strong);
+  transition: box-shadow var(--fast) var(--ease);
 }
 
-.hero-text p a:hover {
+.hero-bio a:hover {
   color: var(--accent);
-  text-decoration-color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent-bright);
 }
 
-/* Portrait: tall, framed, gallery-style */
+/* Photo card */
 .hero-photo {
-  position: relative;
-  justify-self: end;
-  width: min(340px, 100%);
-  animation: rise 1s var(--ease);
-}
-
-.hero-photo::before {
-  content: '';
-  position: absolute;
-  inset: 14px -14px -14px 14px;
-  border: 1px solid var(--accent);
-  opacity: 0.55;
-  pointer-events: none;
-  transition: transform var(--normal) var(--ease);
-}
-
-.hero-photo:hover::before {
-  transform: translate(-5px, -5px);
+  overflow: hidden;
+  min-height: 260px;
 }
 
 .hero-photo img {
   display: block;
   width: 100%;
-  aspect-ratio: 4 / 5;
-  height: auto;
+  height: 100%;
   object-fit: cover;
-  object-position: 50% 28%;
-  filter: saturate(0.94);
-  transition: filter var(--normal) var(--ease);
+  object-position: 50% 30%;
+  transition: transform 500ms var(--ease);
 }
 
 .hero-photo:hover img {
-  filter: saturate(1.05);
+  transform: scale(1.03);
 }
 
-.hero-photo-caption {
-  font-family: var(--font-mono);
-  font-size: 10px;
+/* Stats card */
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  padding: 1.3rem 1.5rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.stat-num {
+  font-family: var(--font-display);
+  font-size: 1.45rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.stat-label {
+  font-size: 11px;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.07em;
   color: var(--text-3);
-  margin-top: 0.9rem;
 }
 
-/* ── Social links ────────────────────────────────────── */
+/* ── Social links — tile row ─────────────────────────── */
 .social-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem 1.6rem;
-  margin-top: 1.9rem;
+  gap: 10px;
+  margin-top: 1.7rem;
 }
 
 .social-link {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  font-family: var(--font-mono);
-  font-size: 11.5px;
+  gap: 8px;
+  font-family: var(--font-display);
+  font-size: 13.5px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--text-2);
-  padding-bottom: 3px;
-  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  background: var(--card-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 9px 16px;
   transition: all var(--normal) var(--ease);
 }
 
 .social-link:hover {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
+  background: var(--accent-bright);
+  border-color: var(--accent-bright);
+  color: var(--accent-ink);
+  transform: translateY(-2px);
 }
 
 .social-link svg {
-  width: 13px;
-  height: 13px;
+  width: 15px;
+  height: 15px;
   fill: currentColor;
 }
 
 /* ████████████████████████████████████████████████████████
-   NEWS — ledger
+   NEWS — feed panel
    ████████████████████████████████████████████████████████ */
 .news-section {
   margin-bottom: var(--section-gap);
 }
 
 .news-fade {
-  max-height: 440px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  max-height: 430px;
   overflow-y: auto;
-  padding-right: 0.75rem;
   scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  scrollbar-color: var(--border-strong) transparent;
 }
 
 .news-fade::-webkit-scrollbar {
-  width: 4px;
+  width: 5px;
 }
 
 .news-fade::-webkit-scrollbar-track {
@@ -331,8 +350,12 @@ h2::after {
 }
 
 .news-fade::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 2px;
+  background: var(--border-strong);
+  border-radius: 3px;
+}
+
+.news-container {
+  padding: 0.6rem 1.7rem;
 }
 
 .news-list {
@@ -342,18 +365,13 @@ h2::after {
 .news-item {
   display: flex;
   flex-wrap: wrap;
-  gap: 0 1.5rem;
+  gap: 0 1.4rem;
   align-items: baseline;
-  padding: 0.8rem 0;
-  border-bottom: 1px solid var(--border-soft);
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--border);
   font-size: 14.5px;
   color: var(--text-2);
-  line-height: 1.65;
-  transition: border-color var(--fast) var(--ease);
-}
-
-.news-item:hover {
-  border-bottom-color: var(--accent);
+  line-height: 1.6;
 }
 
 .news-item:last-child {
@@ -361,107 +379,90 @@ h2::after {
 }
 
 .news-date {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-family: var(--font-display);
+  font-size: 12px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--text-3);
+  color: var(--accent);
   white-space: nowrap;
   flex-shrink: 0;
-  min-width: 90px;
+  min-width: 84px;
 }
 
 .news-item a {
   color: var(--text);
   font-weight: 500;
-  text-decoration: underline;
-  text-decoration-color: var(--border);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
+  box-shadow: inset 0 -1px 0 var(--border-strong);
 }
 
 .news-item a:hover {
   color: var(--accent);
-  text-decoration-color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent-bright);
 }
 
 /* ████████████████████████████████████████████████████████
-   RESEARCH — numbered magazine index
+   RESEARCH — 2-col card grid
    ████████████████████████████████████████████████████████ */
 .research-section {
   margin-bottom: var(--section-gap);
-  counter-reset: paper;
+}
+
+.research-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.1rem;
 }
 
 .paper-card {
   display: flex;
-  flex-direction: row-reverse;
-  gap: 2.5rem;
-  align-items: flex-start;
-  padding: 2.1rem 0;
-  border-bottom: 1px solid var(--border-soft);
-  counter-increment: paper;
-  position: relative;
+  flex-direction: column;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  transition:
+    transform var(--normal) var(--ease),
+    border-color var(--normal) var(--ease),
+    box-shadow var(--normal) var(--ease);
 }
 
-.paper-card:last-of-type {
-  border-bottom: none;
-}
-
-.paper-content {
-  flex: 1;
-  min-width: 0;
-  position: relative;
-  padding-left: 3.6rem;
-}
-
-/* Ghost numeral */
-.paper-content::before {
-  content: counter(paper, decimal-leading-zero);
-  position: absolute;
-  left: 0;
-  top: 0.18em;
-  font-family: var(--font-display);
-  font-size: 1.15rem;
-  font-style: italic;
-  font-weight: 500;
-  color: var(--text-3);
-  transition: color var(--fast) var(--ease);
-}
-
-.paper-card:hover .paper-content::before {
-  color: var(--accent);
+.paper-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--border-strong);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.14);
 }
 
 .paper-image {
-  flex-shrink: 0;
-  width: 150px;
-  border: 1px solid var(--border);
-  padding: 5px;
-  background: var(--bg-elevated);
+  height: 165px;
+  background: var(--card-2);
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
 }
 
 .paper-image img {
-  display: block;
   width: 100%;
-  height: 96px;
+  height: 100%;
   object-fit: cover;
-  filter: saturate(0.92);
-  transition: filter var(--normal) var(--ease);
+  transition: transform 500ms var(--ease);
 }
 
 .paper-card:hover .paper-image img {
-  filter: saturate(1.05);
+  transform: scale(1.04);
+}
+
+.paper-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.4rem 1.5rem 1.5rem;
 }
 
 .paper-title {
   font-family: var(--font-display);
-  font-size: 1.35rem;
-  font-weight: 500;
-  letter-spacing: -0.015em;
+  font-size: 1.12rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   color: var(--text);
-  line-height: 1.3;
+  line-height: 1.32;
   display: block;
   margin-bottom: 0.55rem;
   transition: color var(--fast) var(--ease);
@@ -472,10 +473,10 @@ h2::after {
 }
 
 .paper-authors {
-  font-size: 13px;
+  font-size: 12.5px;
   color: var(--text-3);
   line-height: 1.55;
-  margin-bottom: 0.4rem;
+  margin-bottom: 0.45rem;
 }
 
 .paper-authors .me {
@@ -484,90 +485,92 @@ h2::after {
 }
 
 .paper-venue {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-family: var(--font-display);
+  font-size: 11.5px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
   color: var(--accent);
-  margin-bottom: 0.7rem;
+  margin-bottom: 0.75rem;
+}
+
+.paper-description {
+  font-size: 13px;
+  color: var(--text-2);
+  line-height: 1.66;
+  margin-bottom: 1rem;
 }
 
 .paper-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 1.3rem;
-  margin-bottom: 0.75rem;
+  gap: 7px;
+  margin-top: auto;
 }
 
 .paper-link {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-family: var(--font-display);
+  font-size: 12px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--text-2);
-  padding-bottom: 2px;
-  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  background: var(--card-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 13px;
   transition: all var(--fast) var(--ease);
 }
 
 .paper-link:hover {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
-
-.paper-description {
-  font-size: 13.5px;
-  color: var(--text-2);
-  line-height: 1.72;
-  max-width: 60ch;
+  background: var(--accent-bright);
+  border-color: var(--accent-bright);
+  color: var(--accent-ink);
 }
 
 /* Spotlight badge */
 .paper-venue-spotlight {
   display: inline-block;
-  padding: 1px 8px;
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--accent);
-  border: 1px solid var(--accent);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--accent-ink);
+  background: var(--accent-bright);
+  border-radius: 999px;
+  padding: 1px 9px;
   vertical-align: middle;
-  margin-left: 8px;
+  margin-left: 6px;
 }
 
 /* ████████████████████████████████████████████████████████
-   HEADER
+   FLOATING PILL NAV
    ████████████████████████████████████████████████████████ */
 .site-header {
-  position: sticky;
-  top: 0;
+  position: fixed;
+  top: 1.1rem;
+  left: 0;
+  right: 0;
   z-index: 100;
-  background: color-mix(in srgb, var(--bg) 86%, transparent);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--border-soft);
-  transition: background-color var(--normal) var(--ease);
+  pointer-events: none;
 }
 
 .site-header-inner {
-  max-width: var(--container);
+  pointer-events: auto;
+  width: fit-content;
   margin: 0 auto;
-  padding: 1rem 2.5rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1.4rem;
+  padding: 0.55rem 0.7rem 0.55rem 1.4rem;
+  background: color-mix(in srgb, var(--card) 80%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
 }
 
 .header-logo {
   font-family: var(--font-display);
-  font-style: italic;
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   color: var(--text);
 }
 
@@ -578,16 +581,14 @@ h2::after {
 .header-nav {
   display: flex;
   align-items: center;
-  gap: 1.8rem;
+  gap: 1.1rem;
 }
 
 .header-nav-link {
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-family: var(--font-display);
+  font-size: 13.5px;
   font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--text-3);
+  color: var(--text-2);
 }
 
 .header-nav-link:hover {
@@ -598,9 +599,9 @@ h2::after {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: transparent;
+  width: 34px;
+  height: 34px;
+  background: var(--card-2);
   border: 1px solid var(--border);
   border-radius: 999px;
   color: var(--text-2);
@@ -609,17 +610,17 @@ h2::after {
 }
 
 .theme-toggle:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-  background: var(--accent-soft);
+  background: var(--accent-bright);
+  border-color: var(--accent-bright);
+  color: var(--accent-ink);
 }
 
 .theme-toggle svg {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.6;
+  stroke-width: 1.8;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
@@ -641,17 +642,17 @@ h2::after {
    ████████████████████████████████████████████████████████ */
 .back-to-top {
   position: fixed;
-  bottom: 1.75rem;
-  right: 1.75rem;
+  bottom: 1.6rem;
+  right: 1.6rem;
   z-index: 90;
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 15px;
-  color: var(--text-2);
-  background: var(--bg-elevated);
+  font-size: 16px;
+  color: var(--text);
+  background: var(--card);
   border: 1px solid var(--border);
   border-radius: 999px;
   cursor: pointer;
@@ -659,7 +660,7 @@ h2::after {
   transform: translateY(8px);
   pointer-events: none;
   transition: all var(--normal) var(--ease);
-  box-shadow: 0 6px 18px rgba(20, 16, 12, 0.1);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
 }
 
 .back-to-top.visible {
@@ -669,14 +670,14 @@ h2::after {
 }
 
 .back-to-top:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-  background: var(--accent-soft);
+  background: var(--accent-bright);
+  border-color: var(--accent-bright);
+  color: var(--accent-ink);
   transform: translateY(-2px);
 }
 
 .site-footer {
-  padding: 2.5rem 0 1.5rem;
+  padding: 2rem 0 1.2rem;
   border-top: 1px solid var(--border);
   display: flex;
   align-items: baseline;
@@ -687,39 +688,35 @@ h2::after {
 
 .footer-line {
   font-family: var(--font-display);
-  font-style: italic;
-  font-size: 15px;
+  font-size: 13.5px;
+  font-weight: 500;
   color: var(--text-2);
 }
 
 .footer-meta {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
+  font-size: 12.5px;
   color: var(--text-3);
 }
 
 .footer-meta a {
   color: var(--text-3);
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 2px;
+  box-shadow: inset 0 -1px 0 var(--border-strong);
 }
 
 .footer-meta a:hover {
   color: var(--accent);
-  border-bottom-color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent-bright);
 }
 
 /* ── Motion ──────────────────────────────────────────── */
-@keyframes rise {
+@keyframes pop {
   from {
     opacity: 0;
-    transform: translateY(16px);
+    transform: translateY(14px) scale(0.995);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
   }
 }
 
@@ -727,8 +724,9 @@ h2::after {
 a:focus-visible,
 button:focus-visible,
 [tabindex]:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--accent-bright);
   outline-offset: 3px;
+  border-radius: 6px;
 }
 
 /* ── Reduced motion ──────────────────────────────────── */
@@ -746,45 +744,54 @@ button:focus-visible,
 }
 
 /* ── Responsive ──────────────────────────────────────── */
-@media (max-width: 860px) {
+@media (max-width: 900px) {
   .hero-section {
     grid-template-columns: 1fr;
-    gap: 3rem;
-    min-height: 0;
-    padding: 3rem 0 3.5rem;
+  }
+
+  .hero-side {
+    grid-template-rows: none;
+    grid-template-columns: 1.2fr 1fr;
   }
 
   .hero-photo {
-    justify-self: start;
-    width: min(280px, 80%);
+    min-height: 220px;
   }
 
+  .hero-stats {
+    grid-template-columns: 1fr;
+    align-content: center;
+    gap: 0.9rem;
+  }
+
+  .research-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
   .site-container {
-    padding: 0 1.4rem 1.5rem;
+    padding: 5.5rem 1rem 1.5rem;
+  }
+
+  .hero-text {
+    padding: 1.7rem;
+  }
+
+  .hero-side {
+    grid-template-columns: 1fr;
   }
 
   .site-header-inner {
-    padding: 0.85rem 1.4rem;
+    gap: 0.9rem;
+    padding-left: 1.1rem;
   }
 
   .header-nav {
-    gap: 1.1rem;
+    gap: 0.8rem;
   }
 
-  .paper-card {
-    flex-direction: column;
-    gap: 1.2rem;
-  }
-
-  .paper-image {
-    width: 100%;
-  }
-
-  .paper-image img {
-    height: 165px;
-  }
-
-  .paper-content {
-    padding-left: 2.6rem;
+  .header-nav-link {
+    font-size: 12.5px;
   }
 }


### PR DESCRIPTION
## "Bento" — a structural redesign, not a reskin

Both previous designs shared the same skeleton (single column, hero row, lists). This changes the bones:

- **Typography**: Space Grotesk (geometric display) + Inter — no serif, no monospace
- **Dark-first palette**: near-black `#0a0b0d` card surfaces with an **electric lime** accent; light mode is a clean neutral with olive accent
- **Bento-grid hero**: intro card (topic chips, name, role, bio, social tiles) + photo card + stats card (publications / updates / Llama 3 core contributor)
- **Floating pill nav**: centered, blurred, rounded-full — replaces the full-width header bar
- **Research = 2-column card grid**: image headers, hover lift with shadow, pill-shaped links that fill lime on hover
- **News = feed panel** inside a rounded card
- Social links are tiles that invert to lime on hover; spotlight badge is a filled lime pill

7/7 tests, lint, build + prerender green. All static-HTML/deployment architecture unchanged.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_