### PR TITLE
Expandable papers with on-device AI summaries + arXiv abstracts; mobile polish

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -75,6 +75,20 @@ describe('App', () => {
     expect(document.documentElement.dataset.theme).toBe('light');
   });
 
+  it('expands a paper card to reveal the TL;DR panel', () => {
+    const { container } = renderApp();
+    initSite();
+    const card = container.querySelector('.paper-card')!;
+    const toggle = card.querySelector<HTMLButtonElement>('.paper-expand')!;
+    expect(card.classList.contains('open')).toBe(false);
+    fireEvent.click(toggle);
+    expect(card.classList.contains('open')).toBe(true);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(card.querySelector('.paper-ai')!.textContent!.length).toBeGreaterThan(20);
+    fireEvent.click(toggle);
+    expect(card.classList.contains('open')).toBe(false);
+  });
+
   it('external social links open safely in a new tab', () => {
     const { section } = renderApp();
     const gh = section('.social-links').getByRole('link', { name: /github/i });

--- a/src/components/PaperCard.tsx
+++ b/src/components/PaperCard.tsx
@@ -1,8 +1,18 @@
 import type { Paper } from '../data/papers.tsx';
 
+function arxivId(paper: Paper): string | undefined {
+  for (const link of [{ href: paper.titleHref }, ...paper.links]) {
+    const m = link.href.match(/arxiv\.org\/abs\/([0-9.]+)/);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
 export default function PaperCard({ paper }: { paper: Paper }) {
+  const arxiv = arxivId(paper);
+
   return (
-    <div className="paper-card">
+    <div className="paper-card" data-arxiv={arxiv}>
       <div className="paper-image">
         <img src={paper.image} alt={paper.imageAlt} loading="lazy" />
       </div>
@@ -12,14 +22,37 @@ export default function PaperCard({ paper }: { paper: Paper }) {
         </a>
         <div className="paper-authors">{paper.authors}</div>
         {paper.venue && <div className="paper-venue">{paper.venue}</div>}
+        <p className="paper-description">{paper.description}</p>
         <div className="paper-links">
           {paper.links.map(({ label, href }) => (
             <a className="paper-link" href={href} key={label}>
               {label}
             </a>
           ))}
+          <button type="button" className="paper-expand" aria-expanded="false">
+            TL;DR
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+              <path d="M4 6l4 4 4-4" />
+            </svg>
+          </button>
         </div>
-        <p className="paper-description">{paper.description}</p>
+
+        <div className="paper-extra">
+          <div className="paper-extra-inner">
+            <div className="extra-block">
+              <span className="extra-chip">
+                ✦ TL;DR <em className="ai-src" />
+              </span>
+              <p className="paper-ai">{paper.tldr}</p>
+            </div>
+            {arxiv && (
+              <div className="extra-block">
+                <span className="extra-chip">Abstract</span>
+                <p className="paper-abstract">Loading abstract from arXiv…</p>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/data/papers.tsx
+++ b/src/data/papers.tsx
@@ -14,6 +14,8 @@ export interface Paper {
   venue?: ReactNode;
   links: PaperLink[];
   description: string;
+  /** Hand-written fallback summary, replaced by an on-device AI summary when available. */
+  tldr: string;
 }
 
 const Me = ({ star = false }: { star?: boolean }) => (
@@ -23,6 +25,7 @@ const Me = ({ star = false }: { star?: boolean }) => (
 export const papers: Paper[] = [
   {
     title: 'The Llama 3 Herd of Models',
+    tldr: 'Open 405B-parameter foundation models with a 128K context window, native tool use, and multilingual support — performance comparable to GPT-4, released openly.',
     titleHref: 'https://ai.meta.com/blog/meta-llama-3/',
     image: '/images/llama3-1.png',
     imageAlt: 'Llama 3.1',
@@ -43,6 +46,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Llama-3 Preview Models',
+    tldr: '8B and 70B pretrained and instruction-tuned models that set state-of-the-art performance at their scales on release.',
     titleHref: 'https://ai.meta.com/blog/meta-llama-3/',
     image: '/images/llama-3.png',
     imageAlt: 'Llama 3',
@@ -55,6 +59,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Rainbow Teaming: Open-Ended Generation of Diverse Adversarial Prompts',
+    tldr: 'Quality-diversity search that automatically generates diverse adversarial prompts, exposing LLM vulnerabilities and producing data that measurably improves robustness.',
     titleHref: 'https://arxiv.org/abs/2402.16822',
     image: '/images/rainbow-teaming.png',
     imageAlt: 'Rainbow Teaming',
@@ -78,6 +83,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'GLoRe: When, Where, and How to Improve LLM Reasoning via Global and Local Refinements',
+    tldr: 'Stepwise reward models decide when, where, and how to refine LLM reasoning, lifting a strong RL-finetuned Llama-2 13B by 12% on GSM8K.',
     titleHref: 'https://arxiv.org/abs/2402.10963',
     image: '/images/galore.png',
     imageAlt: 'GLoRe',
@@ -98,6 +104,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Teaching Large Language Models to Reason with Reinforcement Learning',
+    tldr: 'A systematic comparison of expert iteration, PPO, and return-conditioned RL for reasoning — expert iteration proves surprisingly competitive.',
     titleHref: 'https://arxiv.org/abs/2403.04642',
     image: '/images/gsm8k.png',
     imageAlt: 'Teaching LLMs to Reason',
@@ -119,6 +126,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Generalization to New Sequential Decision Making Tasks with In-Context Learning',
+    tldr: 'Transformers trained on diverse offline trajectories learn brand-new sequential decision-making tasks in-context from just a handful of demonstrations.',
     titleHref: 'https://arxiv.org/abs/2312.03801',
     image: '/images/ICL-SDM.png',
     imageAlt: 'In-Context Learning for SDM',
@@ -138,6 +146,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Multi-Objective GFlowNets',
+    tldr: 'Conditional GFlowNets that sample diverse Pareto-optimal candidates, outperforming prior methods for multi-objective drug and materials design.',
     titleHref: 'https://arxiv.org/abs/2210.12765',
     image: '/images/mogfn.png',
     imageAlt: 'Multi-Objective GFlowNets',
@@ -161,6 +170,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Compositional Attention: Disentangling Search and Retrieval',
+    tldr: "Disentangles attention's search and retrieval steps and composes them dynamically — a drop-in replacement for multi-head attention.",
     titleHref: 'https://arxiv.org/abs/2110.09419v1',
     image: '/images/comp-atten.png',
     imageAlt: 'Compositional Attention',
@@ -188,6 +198,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Continual Learning In Environments With Polynomial Mixing Times',
+    tldr: 'Formalizes continual RL as scalable MDPs, proves they exhibit polynomial mixing times, and proposes three sample-efficient algorithms.',
     titleHref: 'https://arxiv.org/abs/2112.07066',
     image: '/images/figure-1-draft-11.png',
     imageAlt: 'Continual Learning',
@@ -210,6 +221,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'Curriculum in Gradient-Based Meta-Reinforcement Learning',
+    tldr: 'Shows MAML is highly sensitive to task distributions; learning a task curriculum instead of uniform sampling substantially improves adaptation.',
     titleHref: 'https://arxiv.org/abs/2002.07956',
     image: '/images/meta-adr.png',
     imageAlt: 'Curriculum in Meta-RL',
@@ -227,6 +239,7 @@ export const papers: Paper[] = [
   },
   {
     title: 'CuNAS — CUriosity-driven Neural-Augmented Simulator',
+    tldr: 'Adds curiosity-driven exploration to neural-augmented simulators, improving sim-to-real transfer of robot policies.',
     titleHref: 'https://arxiv.org/abs/2112.07066',
     image: '/images/r-ss.png',
     imageAlt: 'CuNAS',

--- a/src/site.ts
+++ b/src/site.ts
@@ -7,6 +7,61 @@ declare global {
   }
 }
 
+/** Chrome's built-in on-device Summarizer API (free, private, no key). */
+interface BuiltInSummarizer {
+  availability(): Promise<string>;
+  create(opts: {
+    type?: string;
+    format?: string;
+    length?: string;
+  }): Promise<{ summarize(text: string): Promise<string> }>;
+}
+
+function summarizerApi(): BuiltInSummarizer | undefined {
+  return (globalThis as { Summarizer?: BuiltInSummarizer }).Summarizer;
+}
+
+async function fetchArxivAbstract(id: string): Promise<string> {
+  const res = await fetch(`https://export.arxiv.org/api/query?id_list=${encodeURIComponent(id)}`);
+  if (!res.ok) throw new Error(`arXiv API: ${res.status}`);
+  const xml = new DOMParser().parseFromString(await res.text(), 'text/xml');
+  const summary = xml.querySelector('entry > summary')?.textContent ?? '';
+  return summary.replace(/\s+/g, ' ').trim();
+}
+
+async function loadPaperExtras(card: HTMLElement, extra: HTMLElement): Promise<void> {
+  const id = card.dataset.arxiv;
+  const absEl = extra.querySelector<HTMLElement>('.paper-abstract');
+  const aiEl = extra.querySelector<HTMLElement>('.paper-ai');
+  const srcEl = extra.querySelector<HTMLElement>('.ai-src');
+
+  let abstract = '';
+  if (id && absEl) {
+    try {
+      abstract = await fetchArxivAbstract(id);
+      absEl.textContent = abstract || 'No abstract found.';
+    } catch {
+      absEl.textContent = 'Could not load the abstract right now — try the paper link above.';
+    }
+  }
+
+  // Upgrade the hand-written TL;DR with an on-device AI summary when the
+  // browser ships one (Chrome's Summarizer API). Fails quietly otherwise.
+  try {
+    const api = summarizerApi();
+    if (!api || !abstract || !aiEl) return;
+    if ((await api.availability()) === 'unavailable') return;
+    const summarizer = await api.create({ type: 'tldr', format: 'plain-text', length: 'short' });
+    const summary = (await summarizer.summarize(abstract)).trim();
+    if (summary) {
+      aiEl.textContent = summary;
+      if (srcEl) srcEl.textContent = '· AI, summarized on your device';
+    }
+  } catch {
+    // Keep the baked-in summary.
+  }
+}
+
 /** Wires up the small interactive bits on top of the static HTML. */
 export function initSite(): void {
   document.querySelectorAll<HTMLElement>('.theme-toggle').forEach((btn) => {
@@ -32,6 +87,21 @@ export function initSite(): void {
     window.addEventListener('scroll', update, { passive: true });
     top.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
   }
+
+  document.querySelectorAll<HTMLElement>('.paper-card').forEach((card) => {
+    const btn = card.querySelector<HTMLButtonElement>('.paper-expand');
+    const extra = card.querySelector<HTMLElement>('.paper-extra');
+    if (!btn || !extra || btn.dataset.bound) return;
+    btn.dataset.bound = '1';
+    btn.addEventListener('click', () => {
+      const open = card.classList.toggle('open');
+      btn.setAttribute('aria-expanded', String(open));
+      if (open && !extra.dataset.loaded) {
+        extra.dataset.loaded = '1';
+        void loadPaperExtras(card, extra);
+      }
+    });
+  });
 }
 
 if (document.readyState !== 'loading') {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -576,6 +576,98 @@ h2 {
   color: var(--accent-2);
 }
 
+/* ── Expandable details ──────────────────────────────── */
+.paper-expand {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 12px;
+  cursor: pointer;
+  transition: all var(--fast) var(--ease);
+}
+
+.paper-expand:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.paper-expand svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform var(--normal) var(--ease);
+}
+
+.paper-card.open .paper-expand svg {
+  transform: rotate(180deg);
+}
+
+.paper-extra {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 320ms var(--ease);
+}
+
+.paper-extra-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.paper-card.open .paper-extra {
+  grid-template-rows: 1fr;
+}
+
+.extra-block {
+  margin-top: 1rem;
+  border-left: 2px solid var(--accent-soft);
+  padding-left: 1rem;
+}
+
+.paper-card.open .extra-block:first-child {
+  border-left-color: var(--accent);
+}
+
+.extra-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--accent);
+  margin-bottom: 0.3rem;
+}
+
+.ai-src {
+  font-style: normal;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-3);
+}
+
+.paper-ai,
+.paper-abstract {
+  font-size: 13.5px;
+  line-height: 1.7;
+  color: var(--text-2);
+  max-width: 62ch;
+}
+
 /* Spotlight badge */
 .paper-venue-spotlight {
   display: inline-block;
@@ -803,7 +895,27 @@ button:focus-visible,
 /* ── Responsive ──────────────────────────────────────── */
 @media (max-width: 760px) {
   .site-container {
-    padding: 6rem 1rem 1.5rem;
+    padding: 5.5rem 1rem 1.5rem;
+  }
+
+  .hero-name {
+    text-wrap: balance;
+  }
+
+  .hero-badge {
+    max-width: 100%;
+    flex-wrap: wrap;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .social-links {
+    width: 100%;
+  }
+
+  .social-link {
+    flex: 1 1 auto;
+    justify-content: center;
   }
 
   .hero-highlights {
@@ -836,5 +948,36 @@ button:focus-visible,
 
   .header-nav-link {
     padding: 6px 9px;
+  }
+}
+
+@media (max-width: 430px) {
+  .site-header-inner {
+    padding: 0.7rem 0.8rem;
+  }
+
+  .header-logo {
+    font-size: 14px;
+  }
+
+  .header-nav {
+    gap: 0.1rem;
+  }
+
+  .header-nav-link {
+    font-size: 12.5px;
+    padding: 6px 7px;
+  }
+
+  .hero-name {
+    font-size: 2.2rem;
+  }
+
+  .hero-lede {
+    font-size: 1.05rem;
+  }
+
+  .extra-block {
+    padding-left: 0.8rem;
   }
 }


### PR DESCRIPTION
## Dynamic publications + mobile pass

**Expandable paper cards.** Each research row gets a `TL;DR ⌄` pill that smoothly expands an inline panel containing:

- **AI summary** — uses **Chrome's built-in on-device Summarizer API** when the visitor's browser ships it (free, private, zero API keys/cost; labeled *"AI, summarized on your device"*). Every other browser sees a hand-written TL;DR baked into the static HTML, so the panel always has content instantly.
- **Full abstract** — fetched on demand from the **free arXiv API** (CORS-enabled, no key). Lazy: zero network cost until a card is first expanded, fitting the "infrequently used" expectation.
- Graceful failure: offline/API-down keeps the baked-in summary and shows a friendly note for the abstract.

**Mobile pass:** balanced headline wrapping, wrapping hero badge, full-width stacking CTA buttons, ≤430px tightening of header/nav/type, panel padding tuned for small screens.

## Verification
- 8/8 tests (new test covers expand/collapse + aria-expanded + TL;DR content)
- Production bundle simulated with network blocked: cards expand, fallback summary intact, 0 errors
- lint / format / build + prerender green

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_