### PR TITLE
Add arXiv abstracts fetch workflow

### DIFF
--- a/.github/workflows/fetch-abstracts.yml
+++ b/.github/workflows/fetch-abstracts.yml
@@ -1,0 +1,27 @@
+name: Fetch arXiv abstracts
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch and print abstracts JSON
+        run: |
+          python3 - << 'PY'
+          import json, re, time, urllib.request
+          ids = ["2407.21783","2402.16822","2402.10963","2403.04642","2312.03801",
+                 "2210.12765","2110.09419","2112.07066","2002.07956"]
+          out = {}
+          for i in ids:
+              xml = urllib.request.urlopen(
+                  f"https://export.arxiv.org/api/query?id_list={i}", timeout=30
+              ).read().decode()
+              m = re.search(r"<summary>(.*?)</summary>", xml, re.S)
+              out[i] = re.sub(r"\s+", " ", m.group(1)).strip() if m else ""
+              time.sleep(1)
+          print("ABSTRACTS_JSON_START")
+          print(json.dumps(out, ensure_ascii=False, indent=2))
+          print("ABSTRACTS_JSON_END")
+          PY


### PR DESCRIPTION
Dispatch-only workflow that fetches the arXiv abstracts and prints them as JSON, used to bake abstracts into the static build (the arXiv API has no CORS headers, so browsers can't fetch it directly).

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_