### PR TITLE
News logos + staggered entrance and scroll-reveal animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@fontsource/instrument-sans": "^5.2.8",
         "@fontsource/inter": "^5.2.8",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "simple-icons": "^16.23.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4305,6 +4306,25 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-icons": {
+      "version": "16.23.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.23.0.tgz",
+      "integrity": "sha512-08MaTpxj9zGYUIe38tfELYkaHiGE1YgbrbXmTBf+GPxi5mEqLSORQqOXrP0QKPdaFuzEDSmW5o4xkbLlFhmdCw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@fontsource/instrument-sans": "^5.2.8",
     "@fontsource/inter": "^5.2.8",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "simple-icons": "^16.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/components/NewsSection.tsx
+++ b/src/components/NewsSection.tsx
@@ -1,4 +1,5 @@
 import { newsItems } from '../data/news.tsx';
+import { newsIcons } from '../data/icons.ts';
 
 const VISIBLE = 6;
 
@@ -11,8 +12,15 @@ export default function NewsSection() {
           <ul className="news-list">
             {newsItems.map((item, i) => (
               <li className={i < VISIBLE ? 'news-item' : 'news-item news-hidden'} key={i}>
-                <span className="news-date">{item.date}</span>
-                <span>{item.content}</span>
+                <span className="news-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24">
+                    <path d={newsIcons[item.icon]} />
+                  </svg>
+                </span>
+                <div className="news-body">
+                  <span className="news-date">{item.date}</span>
+                  <span>{item.content}</span>
+                </div>
               </li>
             ))}
           </ul>

--- a/src/data/icons.ts
+++ b/src/data/icons.ts
@@ -1,0 +1,20 @@
+import { siDeepmind, siMeta, siArxiv } from 'simple-icons';
+
+/**
+ * 24x24 fill paths for the news feed chips: real brand marks where they are
+ * recognizable (simple-icons), Material-style glyphs for the rest.
+ */
+export const newsIcons = {
+  deepmind: siDeepmind.path,
+  meta: siMeta.path,
+  arxiv: siArxiv.path,
+  work: 'M20 6h-4V4c0-1.1-.9-2-2-2h-4c-1.1 0-2 .9-2 2v2H4c-1.1 0-2 .9-2 2v11c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6 0h-4V4h4v2z',
+  trophy:
+    'M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H7v2h10v-2h-4v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2zM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8zm14 0c0 1.3-.84 2.4-2 2.82V7h2v1z',
+  mic: 'M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3zm5.91-3c-.49 0-.9.36-.98.85C16.52 14.2 14.47 16 12 16s-4.52-1.8-4.93-4.15c-.08-.49-.49-.85-.98-.85-.61 0-1.09.54-1 1.14.49 3 2.89 5.35 5.91 5.78V20c0 .55.45 1 1 1s1-.45 1-1v-2.08c3.02-.43 5.42-2.78 5.91-5.78.1-.6-.39-1.14-1-1.14z',
+  people:
+    'M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z',
+  school: 'M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z',
+} as const;
+
+export type NewsIcon = keyof typeof newsIcons;

--- a/src/data/news.tsx
+++ b/src/data/news.tsx
@@ -1,13 +1,17 @@
 import type { ReactNode } from 'react';
 
+import type { NewsIcon } from './icons.ts';
+
 export interface NewsItem {
   date: string;
+  icon: NewsIcon;
   content: ReactNode;
 }
 
 export const newsItems: NewsItem[] = [
   {
     date: 'Nov 2025:',
+    icon: 'deepmind',
     content: (
       <>
         Joined <a href="https://deepmind.google/">Google DeepMind</a> as a Research Engineer in the
@@ -17,6 +21,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Oct 2024:',
+    icon: 'work',
     content: (
       <>
         Joined <a href="https://www.reka.ai/">Reka AI</a> as a Member of Technical Staff.
@@ -25,6 +30,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Sep 2024:',
+    icon: 'trophy',
     content: (
       <>
         <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a> got accepted into{' '}
@@ -34,6 +40,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Jul 2024:',
+    icon: 'meta',
     content: (
       <>
         Excited to share that I&apos;m a core contributor to{' '}
@@ -44,6 +51,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Jun 2024:',
+    icon: 'trophy',
     content: (
       <>
         <a href="https://arxiv.org/abs/2403.04642">GLoRe</a> and{' '}
@@ -54,6 +62,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Apr 2024:',
+    icon: 'meta',
     content: (
       <>
         Super happy to release{' '}
@@ -63,6 +72,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Mar 2024:',
+    icon: 'arxiv',
     content: (
       <>
         New preprint on{' '}
@@ -75,6 +85,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Mar 2024:',
+    icon: 'arxiv',
     content: (
       <>
         New preprint on{' '}
@@ -87,6 +98,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Mar 2024:',
+    icon: 'arxiv',
     content: (
       <>
         New preprint on{' '}
@@ -99,6 +111,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Feb 2024:',
+    icon: 'mic',
     content: (
       <>
         Featured on{' '}
@@ -109,6 +122,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Dec 2023:',
+    icon: 'arxiv',
     content: (
       <>
         New preprint on{' '}
@@ -121,6 +135,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Oct 2022:',
+    icon: 'trophy',
     content: (
       <>
         Our work <a href="https://arxiv.org/abs/2210.12765">Multi-Objective GFlowNets</a> got
@@ -130,6 +145,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Aug 2022:',
+    icon: 'trophy',
     content: (
       <>
         Our work{' '}
@@ -142,6 +158,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Aug 2022:',
+    icon: 'people',
     content: (
       <>
         Co-organizing{' '}
@@ -154,6 +171,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Aug 2022:',
+    icon: 'meta',
     content: (
       <>
         Joining <a href="https://ai.facebook.com/">MetaAI</a> as an AI Resident.
@@ -162,6 +180,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Apr 2022:',
+    icon: 'work',
     content: (
       <>
         Joining <a href="https://www.recursion.com/">Recursion</a> as a research intern.
@@ -170,6 +189,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Oct 2021:',
+    icon: 'people',
     content: (
       <>
         Co-organizing{' '}
@@ -182,6 +202,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Oct 2021:',
+    icon: 'trophy',
     content: (
       <>
         Our work on <a href="https://arxiv.org/abs/2110.09419">compositional attention</a> got
@@ -191,6 +212,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Oct 2021:',
+    icon: 'arxiv',
     content: (
       <>
         New preprint:{' '}
@@ -203,6 +225,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: 'Sep 2020:',
+    icon: 'school',
     content: (
       <>
         Started my masters at <a href="https://mila.quebec/">Mila</a>.

--- a/src/site.ts
+++ b/src/site.ts
@@ -53,6 +53,38 @@ async function loadPaperExtras(extra: HTMLElement): Promise<void> {
 
 /** Wires up the small interactive bits on top of the static HTML. */
 export function initSite(): void {
+  // Entrance/reveal animations are gated on this class: without JS the page
+  // is fully visible and static (hard rule after the 2026-06 blank-page saga).
+  document.documentElement.classList.add('js-anim');
+
+  const revealables = document.querySelectorAll<HTMLElement>(
+    '.paper-card, .news-item, .highlight-card',
+  );
+  if ('IntersectionObserver' in window) {
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('in');
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: '0px 0px -8% 0px' },
+    );
+    revealables.forEach((el) => {
+      // Only elements below the fold ever get hidden.
+      if (el.getBoundingClientRect().top > window.innerHeight && !el.classList.contains('pre')) {
+        el.classList.add('pre');
+        io.observe(el);
+      }
+    });
+    // Failsafe: never leave anything hidden.
+    setTimeout(() => {
+      document.querySelectorAll('.pre:not(.in)').forEach((el) => el.classList.add('in'));
+    }, 2500);
+  }
+
   document.querySelectorAll<HTMLElement>('.theme-toggle').forEach((btn) => {
     if (btn.dataset.bound) return;
     btn.dataset.bound = '1';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -394,14 +394,44 @@ h2 {
 
 .news-item {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0 1.3rem;
-  align-items: baseline;
+  gap: 0.95rem;
+  align-items: flex-start;
   padding: 0.85rem 0;
   border-bottom: 1px solid var(--border);
   font-size: 14.5px;
   color: var(--text-2);
   line-height: 1.6;
+}
+
+.news-icon {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-soft);
+  border-radius: 9px;
+  margin-top: 2px;
+  transition: transform var(--normal) var(--ease);
+}
+
+.news-item:hover .news-icon {
+  transform: scale(1.12) rotate(-4deg);
+}
+
+.news-icon svg {
+  width: 15px;
+  height: 15px;
+  fill: var(--accent);
+}
+
+.news-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 1.3rem;
+  align-items: baseline;
+  min-width: 0;
 }
 
 .news-item:last-child {
@@ -924,6 +954,62 @@ h2 {
 }
 
 /* ── Motion ──────────────────────────────────────────── */
+/* Scroll reveals: only applied by JS to below-the-fold elements. */
+html.js-anim .pre {
+  opacity: 0;
+  transform: translateY(14px);
+  transition:
+    opacity 0.55s var(--ease),
+    transform 0.55s var(--ease);
+}
+
+html.js-anim .pre.in {
+  opacity: 1;
+  transform: none;
+}
+
+/* Hero entrance: staggered children when JS is confirmed running. */
+html.js-anim .hero-section {
+  animation: none;
+}
+
+html.js-anim .hero-text > * {
+  animation: rise 0.55s var(--ease) backwards;
+}
+
+html.js-anim .hero-text > *:nth-child(1) {
+  animation-delay: 0.02s;
+}
+html.js-anim .hero-text > *:nth-child(2) {
+  animation-delay: 0.08s;
+}
+html.js-anim .hero-text > *:nth-child(3) {
+  animation-delay: 0.14s;
+}
+html.js-anim .hero-text > *:nth-child(4) {
+  animation-delay: 0.2s;
+}
+html.js-anim .hero-text > *:nth-child(5) {
+  animation-delay: 0.26s;
+}
+html.js-anim .hero-text > *:nth-child(6) {
+  animation-delay: 0.32s;
+}
+
+html.js-anim .hero-highlights .highlight-card {
+  animation: rise 0.55s var(--ease) backwards;
+}
+
+html.js-anim .hero-highlights .highlight-card:nth-child(1) {
+  animation-delay: 0.38s;
+}
+html.js-anim .hero-highlights .highlight-card:nth-child(2) {
+  animation-delay: 0.46s;
+}
+html.js-anim .hero-highlights .highlight-card:nth-child(3) {
+  animation-delay: 0.54s;
+}
+
 @keyframes rise {
   from {
     opacity: 0;


### PR DESCRIPTION
## News icons

Every news item gets a 30px accent-tinted icon chip — **real brand marks** where recognizable (DeepMind, Meta, arXiv via `simple-icons`) and Material-style category glyphs elsewhere (briefcase for roles, trophy for acceptances, mic for the podcast, community, graduation cap). Monochrome, theme-aware, with a subtle scale/tilt on row hover. Data-driven: each item declares its `icon` in `src/data/news.tsx`.

## Animations

- **Staggered hero entrance** — chips → name → role → bio → CTAs → highlight cards rise in sequence
- **Scroll-triggered reveals** for paper cards, news items, and highlight cards

Safety rules from this project's history are baked in: all motion is gated on a `js-anim` class added at runtime (no JS → fully visible static page), only below-the-fold elements are ever hidden, a 2.5 s failsafe reveals anything missed, and `prefers-reduced-motion` disables it all.

**Verified:** zero `pre`-hidden elements in the static HTML, 20 icon chips present, gate engages under JS with 0 errors. 10/10 tests, lint/build green.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_