### PR TITLE
Org logos in the About section (inline links + highlight cards)

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,32 @@
+import type { ReactNode } from 'react';
 import SocialLinks from './SocialLinks.tsx';
+import type { OrgLogo } from '../data/news.tsx';
+
+function Org({ href, logo, children }: { href: string; logo: OrgLogo; children: ReactNode }) {
+  return (
+    <a href={href}>
+      <img
+        className="org-inline"
+        src={`/logos/${logo}.png`}
+        alt=""
+        width={16}
+        height={16}
+        loading="lazy"
+      />
+      {children}
+    </a>
+  );
+}
+
+function HighlightLogos({ logos }: { logos: OrgLogo[] }) {
+  return (
+    <span className="highlight-logos" aria-hidden="true">
+      {logos.map((logo) => (
+        <img key={logo} src={`/logos/${logo}.png`} alt="" width={20} height={20} loading="lazy" />
+      ))}
+    </span>
+  );
+}
 
 export default function Hero() {
   return (
@@ -14,7 +42,10 @@ export default function Hero() {
         />
         <p className="hero-badge">
           <span className="badge-dot" aria-hidden="true" />
-          Research Engineer at&nbsp;<a href="https://deepmind.google/">Google DeepMind</a>
+          Research Engineer at&nbsp;
+          <Org href="https://deepmind.google/" logo="deepmind">
+            Google DeepMind
+          </Org>
         </p>
 
         <h1 className="hero-name">Sharath Chandra Raparthy</h1>
@@ -25,14 +56,25 @@ export default function Hero() {
         </p>
 
         <p className="hero-bio">
-          Previously at <a href="https://www.reka.ai/">Reka AI</a> building multimodal agents, and
-          an AI Resident at <a href="https://ai.meta.com/">FAIR (Meta)</a> — core contributor to{' '}
-          <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> and co-lead of{' '}
-          <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>. Master&apos;s from{' '}
-          <a href="https://mila.quebec/en/">Mila</a> with{' '}
-          <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>; GFlowNets for drug
-          discovery at <a href="https://www.recursion.com">Recursion</a>. Off the clock: long runs,
-          cooking, books, a camera.
+          Previously at{' '}
+          <Org href="https://www.reka.ai/" logo="reka">
+            Reka AI
+          </Org>{' '}
+          building multimodal agents, and an AI Resident at{' '}
+          <Org href="https://ai.meta.com/" logo="meta">
+            FAIR (Meta)
+          </Org>{' '}
+          — core contributor to <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> and co-lead
+          of <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>. Master&apos;s from{' '}
+          <Org href="https://mila.quebec/en/" logo="mila">
+            Mila
+          </Org>{' '}
+          with <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>; GFlowNets for drug
+          discovery at{' '}
+          <Org href="https://www.recursion.com" logo="recursion">
+            Recursion
+          </Org>
+          . Off the clock: long runs, cooking, books, a camera.
         </p>
 
         <SocialLinks />
@@ -40,16 +82,19 @@ export default function Hero() {
 
       <div className="hero-highlights">
         <div className="highlight-card">
+          <HighlightLogos logos={['meta']} />
           <span className="highlight-kicker">Flagship</span>
           <span className="highlight-title">Llama 3</span>
           <span className="highlight-sub">Core contributor — tool-use &amp; math reasoning</span>
         </div>
         <div className="highlight-card">
+          <HighlightLogos logos={['neurips', 'icml', 'iclr']} />
           <span className="highlight-kicker">Published at</span>
           <span className="highlight-title">NeurIPS · ICML · ICLR</span>
           <span className="highlight-sub">11 papers, incl. an ICLR Spotlight</span>
         </div>
         <div className="highlight-card">
+          <HighlightLogos logos={['deepmind']} />
           <span className="highlight-kicker">Focus</span>
           <span className="highlight-title">Open-Endedness</span>
           <span className="highlight-sub">LLM reasoning · in-context RL</span>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,10 +1,9 @@
-import type { ReactNode } from 'react';
 import SocialLinks from './SocialLinks.tsx';
 import type { OrgLogo } from '../data/news.tsx';
 
-function Org({ href, logo, children }: { href: string; logo: OrgLogo; children: ReactNode }) {
+function Org({ href, logo, label }: { href: string; logo: OrgLogo; label: string }) {
   return (
-    <a href={href}>
+    <a className="org-link" href={href}>
       <img
         className="org-inline"
         src={`/logos/${logo}.png`}
@@ -13,7 +12,7 @@ function Org({ href, logo, children }: { href: string; logo: OrgLogo; children: 
         height={16}
         loading="lazy"
       />
-      {children}
+      <span>{label}</span>
     </a>
   );
 }
@@ -43,9 +42,7 @@ export default function Hero() {
         <p className="hero-badge">
           <span className="badge-dot" aria-hidden="true" />
           Research Engineer at&nbsp;
-          <Org href="https://deepmind.google/" logo="deepmind">
-            Google DeepMind
-          </Org>
+          <Org href="https://deepmind.google/" logo="deepmind" label="Google DeepMind" />
         </p>
 
         <h1 className="hero-name">Sharath Chandra Raparthy</h1>
@@ -56,25 +53,15 @@ export default function Hero() {
         </p>
 
         <p className="hero-bio">
-          Previously at{' '}
-          <Org href="https://www.reka.ai/" logo="reka">
-            Reka AI
-          </Org>{' '}
-          building multimodal agents, and an AI Resident at{' '}
-          <Org href="https://ai.meta.com/" logo="meta">
-            FAIR (Meta)
-          </Org>{' '}
-          — core contributor to <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> and co-lead
-          of <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>. Master&apos;s from{' '}
-          <Org href="https://mila.quebec/en/" logo="mila">
-            Mila
-          </Org>{' '}
-          with <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>; GFlowNets for drug
-          discovery at{' '}
-          <Org href="https://www.recursion.com" logo="recursion">
-            Recursion
-          </Org>
-          . Off the clock: long runs, cooking, books, a camera.
+          Previously at <Org href="https://www.reka.ai/" logo="reka" label="Reka AI" /> building
+          multimodal agents, and an AI Resident at{' '}
+          <Org href="https://ai.meta.com/" logo="meta" label="FAIR (Meta)" /> — core contributor to{' '}
+          <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> and co-lead of{' '}
+          <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>. Master&apos;s from{' '}
+          <Org href="https://mila.quebec/en/" logo="mila" label="Mila" /> with{' '}
+          <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>; GFlowNets for drug
+          discovery at <Org href="https://www.recursion.com" logo="recursion" label="Recursion" />.
+          Off the clock: long runs, cooking, books, a camera.
         </p>
 
         <SocialLinks />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -265,6 +265,20 @@ h2 {
   box-shadow: inset 0 -2px 0 var(--accent);
 }
 
+/* ── Inline org logos in prose ───────────────────────── */
+.org-inline {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 1.5px;
+  vertical-align: -3px;
+  margin-right: 5px;
+}
+
 /* ── CTAs (social links) ─────────────────────────────── */
 .social-links {
   display: flex;
@@ -325,6 +339,7 @@ h2 {
 }
 
 .highlight-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 3px;
@@ -345,6 +360,24 @@ h2 {
   box-shadow:
     inset 0 1px 0 var(--highlight),
     var(--shadow-lift);
+}
+
+.highlight-logos {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: flex;
+  gap: 4px;
+}
+
+.highlight-logos img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2.5px;
 }
 
 .highlight-kicker {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -266,6 +266,21 @@ h2 {
 }
 
 /* ── Inline org logos in prose ───────────────────────── */
+.hero-bio a.org-link,
+.hero-badge a.org-link {
+  box-shadow: none;
+  white-space: nowrap;
+}
+
+.hero-bio a.org-link span {
+  box-shadow: inset 0 -1px 0 var(--border-strong);
+  transition: box-shadow var(--fast) var(--ease);
+}
+
+.hero-bio a.org-link:hover span {
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
 .org-inline {
   display: inline-block;
   width: 16px;
@@ -381,6 +396,7 @@ h2 {
 }
 
 .highlight-kicker {
+  padding-right: 80px;
   font-size: 10.5px;
   font-weight: 600;
   text-transform: uppercase;
@@ -467,6 +483,7 @@ h2 {
   gap: 0 1.3rem;
   align-items: baseline;
   min-width: 0;
+  padding-top: 4px;
 }
 
 .news-item:last-child {


### PR DESCRIPTION
Extends the real-logo treatment into the About/hero section:

- **Inline logo chips** (16px, white tile) inside every organization link in the bio and the status badge — DeepMind, Reka, Meta, Mila, Recursion — so the career story reads visually as well as textually
- **Highlight cards** get corner logo tiles: Meta on the Llama 3 card, the NeurIPS/ICML/ICLR trio on the publications card, DeepMind on the Focus card

Logos have empty alt text, so link accessible names are unchanged. 10/10 tests, lint/build green.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_