### PR TITLE
Research-grounded copy, Reka Research/Flash 3, X profile + ⌘K command palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <meta name="author" content="Sharath Chandra Raparthy" />
     <meta
       name="description"
-      content="Sharath Chandra Raparthy — Research Engineer at Google DeepMind working on open-endedness. Previously at FAIR (Meta), Reka AI, and Mila. Core contributor to Llama 3."
+      content="Sharath Chandra Raparthy — Research Engineer at Google DeepMind, working on open-endedness and recursive self-improvement. Core contributor to Llama 3 and Reka Research; previously FAIR (Meta), Reka AI, and Mila."
     />
     <link rel="canonical" href="https://sharathraparthy.github.io/" />
 
@@ -40,7 +40,7 @@
     />
     <meta
       property="og:description"
-      content="Research Engineer at Google DeepMind working on open-endedness. Previously at FAIR (Meta), Reka AI, and Mila. Core contributor to Llama 3."
+      content="Research Engineer at Google DeepMind — open-endedness & recursive self-improvement. Core contributor to Llama 3 and Reka Research."
     />
     <meta property="og:image" content="https://sharathraparthy.github.io/og.png" />
     <meta property="og:image:width" content="1200" />
@@ -52,7 +52,7 @@
     />
     <meta
       name="twitter:description"
-      content="Research Engineer at Google DeepMind working on open-endedness. Previously at FAIR (Meta), Reka AI, and Mila. Core contributor to Llama 3."
+      content="Research Engineer at Google DeepMind — open-endedness & recursive self-improvement. Core contributor to Llama 3 and Reka Research."
     />
     <meta name="twitter:image" content="https://sharathraparthy.github.io/og.png" />
 
@@ -70,6 +70,7 @@
         "email": "mailto:sharathraparthy@gmail.com",
         "sameAs": [
           "https://github.com/SharathRaparthy",
+          "https://x.com/sharathraparthy",
           "https://scholar.google.ca/citations?user=S1R0_UMAAAAJ&hl=en"
         ]
       }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -111,6 +111,19 @@ describe('App', () => {
     expect(panel.classList.contains('expanded')).toBe(false);
   });
 
+  it('opens the command palette and lists every paper', () => {
+    const { container } = renderApp();
+    initSite();
+    const palette = container.querySelector<HTMLElement>('.cmdk')!;
+    expect(palette.hidden).toBe(true);
+    container.querySelector<HTMLButtonElement>('.cmdk-trigger')!.click();
+    expect(palette.hidden).toBe(false);
+    const paperItems = [...palette.querySelectorAll('.cmdk-item')].filter((el) =>
+      el.querySelector('.cmdk-kind')?.textContent?.includes('Paper'),
+    );
+    expect(paperItems).toHaveLength(papers.length);
+  });
+
   it('external social links open safely in a new tab', () => {
     const { section } = renderApp();
     const gh = section('.social-links').getByRole('link', { name: /github/i });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import NewsSection from './components/NewsSection.tsx';
 import ResearchSection from './components/ResearchSection.tsx';
 import Footer from './components/Footer.tsx';
 import BackToTop from './components/BackToTop.tsx';
+import CommandPalette from './components/CommandPalette.tsx';
 
 export default function App() {
   return (
@@ -19,6 +20,7 @@ export default function App() {
         <Footer />
       </div>
       <BackToTop />
+      <CommandPalette />
     </>
   );
 }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,78 @@
+import { papers } from '../data/papers.tsx';
+
+interface Cmd {
+  label: string;
+  kind: string;
+  href?: string;
+  external?: boolean;
+  action?: string;
+  hint?: string;
+}
+
+const commands: Cmd[] = [
+  { label: 'About', kind: 'Section', href: '#about' },
+  { label: 'News', kind: 'Section', href: '#news' },
+  { label: 'Research', kind: 'Section', href: '#research' },
+  { label: 'Copy email address', kind: 'Action', action: 'copy-email', hint: '⏎' },
+  { label: 'Download CV', kind: 'Action', href: '/sharath-raparthy-cv.pdf', external: true },
+  { label: 'Toggle light / dark theme', kind: 'Action', action: 'toggle-theme' },
+  { label: 'GitHub', kind: 'Profile', href: 'https://github.com/SharathRaparthy', external: true },
+  { label: 'X (Twitter)', kind: 'Profile', href: 'https://x.com/sharathraparthy', external: true },
+  {
+    label: 'Google Scholar',
+    kind: 'Profile',
+    href: 'https://scholar.google.ca/citations?user=S1R0_UMAAAAJ&hl=en',
+    external: true,
+  },
+  ...papers.map((p): Cmd => ({ label: p.title, kind: 'Paper', href: p.titleHref, external: true })),
+];
+
+export default function CommandPalette() {
+  return (
+    <div className="cmdk" role="dialog" aria-modal="true" aria-label="Command menu" hidden>
+      <div className="cmdk-overlay" data-cmdk-close />
+      <div className="cmdk-panel" role="document">
+        <input
+          className="cmdk-input"
+          type="text"
+          placeholder="Jump to a section, paper, or action…"
+          aria-label="Search commands"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <ul className="cmdk-list" role="listbox" aria-label="Commands">
+          {commands.map((c) => {
+            const inner = (
+              <>
+                <span className="cmdk-label">{c.label}</span>
+                {c.hint && <kbd className="cmdk-hint">{c.hint}</kbd>}
+                <span className="cmdk-kind">{c.kind}</span>
+              </>
+            );
+            const common = { className: 'cmdk-item', role: 'option' as const };
+            return (
+              <li key={c.label} className="cmdk-row">
+                {c.href ? (
+                  <a
+                    {...common}
+                    href={c.href}
+                    {...(c.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                  >
+                    {inner}
+                  </a>
+                ) : (
+                  <button type="button" {...common} data-cmdk-action={c.action}>
+                    {inner}
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+        <p className="cmdk-empty" hidden>
+          No matches.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,6 +19,14 @@ export default function Header() {
           ))}
           <button
             type="button"
+            className="cmdk-trigger"
+            aria-label="Open command menu"
+            title="Search — press Command-K or Control-K"
+          >
+            <kbd>⌘K</kbd>
+          </button>
+          <button
+            type="button"
             className="theme-toggle"
             aria-label="Toggle color theme"
             title="Toggle color theme"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -16,23 +16,35 @@ export default function Hero() {
           <div>
             <h1 className="hero-name">Sharath Chandra Raparthy</h1>
             <p className="hero-role">
-              Research Engineer, <a href="https://deepmind.google/">Google DeepMind</a>
+              Research Engineer · <a href="https://deepmind.google/">Google DeepMind</a>
             </p>
           </div>
         </div>
 
         <p className="hero-bio">
-          I work on open-endedness — building systems that keep inventing, learning, and surprising
-          us. Previously a Member of Technical Staff at <a href="https://www.reka.ai/">Reka AI</a>,
-          and an AI Resident at <a href="https://ai.meta.com/">FAIR (Meta)</a>, where I was a core
-          contributor to <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> and co-led{' '}
-          <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>.
+          I work on open-endedness — systems that never stop learning, inventing their own
+          challenges and improving without a fixed ceiling. Lately I&apos;m most excited about{' '}
+          <strong>recursive self-improvement</strong>: learners that get better at getting better.
         </p>
         <p className="hero-bio">
-          I hold a Master&apos;s from <a href="https://mila.quebec/en/">Mila</a>, advised by{' '}
-          <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>, and worked on GFlowNets
-          for drug discovery at <a href="https://www.recursion.com">Recursion</a>. Off the clock:
-          long runs, cooking, books, and a camera.
+          Before DeepMind I was a Member of Technical Staff at{' '}
+          <a href="https://www.reka.ai/">Reka AI</a>, where I drove the core development of{' '}
+          <a href="https://reka.ai/products/research">Reka Research</a> — an agent that answers hard
+          questions by reasoning over the open web and private documents. I led its supervised
+          fine-tuning and helped push it to state-of-the-art accuracy on SimpleQA and Research-Eval,
+          ahead of systems from OpenAI, Anthropic, and Perplexity, and worked on the RL fine-tuning
+          behind the open-source{' '}
+          <a href="https://reka.ai/news/introducing-reka-flash">Reka Flash 3</a>.
+        </p>
+        <p className="hero-bio">
+          Earlier, as an AI Resident at <a href="https://ai.meta.com/">FAIR (Meta)</a>, I was a core
+          contributor to <a href="https://arxiv.org/abs/2407.21783">Llama 3</a> — building its
+          tool-use and mathematical reasoning — and co-led{' '}
+          <a href="https://arxiv.org/abs/2402.16822">Rainbow Teaming</a>, an open-ended method for
+          red-teaming LLMs. I hold a Master&apos;s from <a href="https://mila.quebec/en/">Mila</a>,
+          advised by <a href="https://sites.google.com/site/irinarish/">Irina Rish</a>, and interned
+          at <a href="https://www.recursion.com">Recursion</a> on GFlowNets for drug discovery. Off
+          the clock: long runs, cooking, books, and a camera.
         </p>
 
         <SocialLinks />

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -25,6 +25,14 @@ export default function ResearchSection() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(scholarlyData) }}
       />
+      <p className="section-lead">
+        My research is about systems that keep getting better on their own — generating their own
+        challenges, reasoning through them, and improving open-endedly, with recursive
+        self-improvement as the north star. That thread connects open-ended red-teaming (Rainbow
+        Teaming), reinforcement learning for reasoning (GLoRe, Llama 3, Reka Flash 3), research
+        agents that reason over the web (Reka Research), in-context and continual RL, and generative
+        models for scientific discovery (GFlowNets).
+      </p>
       <div className="research-grid">
         {papers.map((paper) => (
           <PaperCard paper={paper} key={paper.title} />

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -8,6 +8,7 @@ const links: SocialLink[] = [
   { label: 'Email', href: 'mailto:sharathraparthy@gmail.com' },
   { label: 'CV', href: '/sharath-raparthy-cv.pdf', external: true },
   { label: 'GitHub', href: 'https://github.com/SharathRaparthy', external: true },
+  { label: 'X', href: 'https://x.com/sharathraparthy', external: true },
   {
     label: 'Google Scholar',
     href: 'https://scholar.google.ca/citations?user=S1R0_UMAAAAJ&hl=en',

--- a/src/data/news.tsx
+++ b/src/data/news.tsx
@@ -32,6 +32,27 @@ export const newsItems: NewsItem[] = [
     ),
   },
   {
+    date: 'Jul 2025:',
+    icon: 'reka',
+    content: (
+      <>
+        Released <a href="https://reka.ai/products/research">Reka Research</a> — a web-browsing
+        research agent I helped build, reaching state-of-the-art accuracy on SimpleQA and
+        Research-Eval.
+      </>
+    ),
+  },
+  {
+    date: 'Mar 2025:',
+    icon: 'reka',
+    content: (
+      <>
+        Open-sourced <a href="https://reka.ai/news/introducing-reka-flash">Reka Flash 3</a>, a 21B
+        reasoning model trained from scratch.
+      </>
+    ),
+  },
+  {
     date: 'Oct 2024:',
     icon: 'reka',
     content: (

--- a/src/site.ts
+++ b/src/site.ts
@@ -51,6 +51,111 @@ async function loadPaperExtras(extra: HTMLElement): Promise<void> {
   }
 }
 
+/** ⌘K / Ctrl-K command palette: jump to sections, papers, or actions. */
+function setupCommandPalette(): void {
+  const palette = document.querySelector<HTMLElement>('.cmdk');
+  const input = palette?.querySelector<HTMLInputElement>('.cmdk-input');
+  const list = palette?.querySelector<HTMLElement>('.cmdk-list');
+  const empty = palette?.querySelector<HTMLElement>('.cmdk-empty');
+  if (!palette || !input || !list || !empty || palette.dataset.bound) return;
+  palette.dataset.bound = '1';
+
+  const items = () => [...list.querySelectorAll<HTMLElement>('.cmdk-item')];
+  const visible = () => items().filter((el) => !(el.closest('.cmdk-row') as HTMLElement).hidden);
+  let active = -1;
+  let lastFocused: HTMLElement | null = null;
+
+  const setActive = (i: number) => {
+    const vis = visible();
+    active = Math.max(0, Math.min(i, vis.length - 1));
+    items().forEach((el) => el.classList.remove('active'));
+    vis[active]?.classList.add('active');
+    vis[active]?.scrollIntoView?.({ block: 'nearest' });
+  };
+
+  const open = () => {
+    lastFocused = document.activeElement as HTMLElement;
+    palette.hidden = false;
+    document.body.style.overflow = 'hidden';
+    requestAnimationFrame(() => {
+      palette.classList.add('open');
+      input.value = '';
+      input.focus();
+      filter();
+    });
+  };
+
+  const close = () => {
+    palette.classList.remove('open');
+    document.body.style.overflow = '';
+    setTimeout(() => {
+      palette.hidden = true;
+    }, 160);
+    lastFocused?.focus();
+  };
+
+  const filter = () => {
+    const q = input.value.trim().toLowerCase();
+    let shown = 0;
+    items().forEach((el) => {
+      const row = el.closest('.cmdk-row') as HTMLElement;
+      const text = el.querySelector('.cmdk-label')?.textContent?.toLowerCase() ?? '';
+      const ok = q === '' || text.includes(q);
+      row.hidden = !ok;
+      if (ok) shown += 1;
+    });
+    empty.hidden = shown > 0;
+    setActive(0);
+  };
+
+  input.addEventListener('input', filter);
+
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      if (palette.hidden) open();
+      else close();
+    } else if (!palette.hidden) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActive(active + 1);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActive(active - 1);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        visible()[active]?.click();
+      }
+    }
+  });
+
+  document.querySelector('.cmdk-trigger')?.addEventListener('click', open);
+  palette.querySelector('[data-cmdk-close]')?.addEventListener('click', close);
+
+  list.addEventListener('click', (e) => {
+    const item = (e.target as HTMLElement).closest<HTMLElement>('.cmdk-item');
+    if (!item) return;
+    const action = item.dataset.cmdkAction;
+    if (action === 'copy-email') {
+      void navigator.clipboard?.writeText('sharathraparthy@gmail.com');
+    } else if (action === 'toggle-theme') {
+      document.querySelector<HTMLElement>('.theme-toggle')?.click();
+    }
+    // Links navigate on their own; just close the palette.
+    close();
+  });
+
+  list.addEventListener('mousemove', (e) => {
+    const item = (e.target as HTMLElement).closest<HTMLElement>('.cmdk-item');
+    if (!item) return;
+    const i = visible().indexOf(item);
+    if (i >= 0 && i !== active) setActive(i);
+  });
+}
+
 /** Wires up the small interactive bits on top of the static HTML. */
 export function initSite(): void {
   // Entrance/reveal animations are gated on this class: without JS the page
@@ -152,6 +257,8 @@ export function initSite(): void {
       newsToggle.textContent = open ? 'Show fewer' : fullLabel;
     });
   }
+
+  setupCommandPalette();
 
   // Highlight the nav link of the section currently in view.
   const navLinks = [...document.querySelectorAll<HTMLAnchorElement>('.header-nav-link')];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -161,6 +161,11 @@ h2 {
   margin-bottom: 1rem;
 }
 
+.hero-bio strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
 .hero-bio a {
   color: var(--text);
   text-decoration: underline;
@@ -287,6 +292,14 @@ h2 {
    ████████████████████████████████████████████████████████ */
 .research-section {
   margin-bottom: var(--gap);
+}
+
+.section-lead {
+  font-size: 1.02rem;
+  line-height: 1.7;
+  color: var(--text-2);
+  max-width: 60ch;
+  margin-bottom: 2rem;
 }
 
 .research-grid {
@@ -552,6 +565,33 @@ h2 {
   text-decoration: none;
 }
 
+.cmdk-trigger {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.cmdk-trigger kbd {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--text-3);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 6px;
+  transition:
+    color var(--fast) var(--ease),
+    border-color var(--fast) var(--ease);
+}
+
+.cmdk-trigger:hover kbd {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
 .theme-toggle {
   display: inline-flex;
   align-items: center;
@@ -676,6 +716,138 @@ button:focus-visible,
   outline: 2px solid var(--accent);
   outline-offset: 3px;
   border-radius: 3px;
+}
+
+/* ████████████████████████████████████████████████████████
+   COMMAND PALETTE (⌘K)
+   ████████████████████████████████████████████████████████ */
+.cmdk[hidden] {
+  display: none;
+}
+
+.cmdk {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 12vh 1rem 1rem;
+}
+
+.cmdk-overlay {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, #000 38%, transparent);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  opacity: 0;
+  transition: opacity 160ms var(--ease);
+}
+
+.cmdk.open .cmdk-overlay {
+  opacity: 1;
+}
+
+.cmdk-panel {
+  position: relative;
+  width: 100%;
+  max-width: 540px;
+  max-height: 60vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(-6px) scale(0.99);
+  transition:
+    opacity 160ms var(--ease),
+    transform 160ms var(--ease);
+}
+
+.cmdk.open .cmdk-panel {
+  opacity: 1;
+  transform: none;
+}
+
+.cmdk-input {
+  flex-shrink: 0;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  color: var(--text);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 1.15rem;
+  outline: none;
+}
+
+.cmdk-input::placeholder {
+  color: var(--text-3);
+}
+
+.cmdk-list {
+  list-style: none;
+  overflow-y: auto;
+  padding: 0.4rem;
+  scrollbar-width: thin;
+}
+
+.cmdk-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: 0.92rem;
+  text-align: left;
+  color: var(--text);
+  background: none;
+  border: none;
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+  cursor: pointer;
+}
+
+.cmdk-item:hover {
+  text-decoration: none;
+}
+
+.cmdk-item.active {
+  background: color-mix(in srgb, var(--accent) 13%, transparent);
+}
+
+.cmdk-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cmdk-kind {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.cmdk-hint {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-3);
+}
+
+.cmdk-empty {
+  padding: 1.2rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--text-3);
 }
 
 /* ████████████████████████████████████████████████████████


### PR DESCRIPTION
## Better text (researched + verified)

Rewrote the copy using the résumé plus verified public sources (Reka Research, Reka Flash 3 launch coverage):

- **Hero bio** leads with the current focus — open-endedness and **recursive self-improvement** — then foregrounds the Reka work: drove core development of **Reka Research** (web + private-document research agent), led its SFT to **state-of-the-art on SimpleQA & Research-Eval** ahead of OpenAI/Anthropic/Perplexity, plus the RL fine-tuning behind open-source **Reka Flash 3**; followed by Llama 3 tool-use, Rainbow Teaming, Mila, Recursion.
- **Research statement** added under the Research heading.
- **News**: added *Reka Research* (Jul 2025) and *Reka Flash 3* (Mar 2025) with the Reka logo.
- Added **X/Twitter** to the links row, command palette, and JSON-LD `sameAs`; refreshed meta/OG descriptions.

## New feature — ⌘K command palette

A hidden, keyboard-driven palette (⌘K / Ctrl-K, or the subtle chip in the header): fuzzy-jump to any section or paper, copy email, download CV, open profiles, toggle theme. Arrow/Enter/Escape navigation, accessible dialog, invisible until summoned.

11 tests pass (added palette test); no-JS render and clean boot verified.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_