### PR TITLE
Correct Reka Flash 3 attribution (remove RL fine-tuning claim)

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -32,9 +32,7 @@ export default function Hero() {
           <a href="https://reka.ai/products/research">Reka Research</a> — an agent that answers hard
           questions by reasoning over the open web and private documents. I led its supervised
           fine-tuning and helped push it to state-of-the-art accuracy on SimpleQA and Research-Eval,
-          ahead of systems from OpenAI, Anthropic, and Perplexity, and worked on the RL fine-tuning
-          behind the open-source{' '}
-          <a href="https://reka.ai/news/introducing-reka-flash">Reka Flash 3</a>.
+          ahead of systems from OpenAI, Anthropic, and Perplexity.
         </p>
         <p className="hero-bio">
           Earlier, as an AI Resident at <a href="https://ai.meta.com/">FAIR (Meta)</a>, I was a core

--- a/src/components/ResearchSection.tsx
+++ b/src/components/ResearchSection.tsx
@@ -29,9 +29,9 @@ export default function ResearchSection() {
         My research is about systems that keep getting better on their own — generating their own
         challenges, reasoning through them, and improving open-endedly, with recursive
         self-improvement as the north star. That thread connects open-ended red-teaming (Rainbow
-        Teaming), reinforcement learning for reasoning (GLoRe, Llama 3, Reka Flash 3), research
-        agents that reason over the web (Reka Research), in-context and continual RL, and generative
-        models for scientific discovery (GFlowNets).
+        Teaming), reinforcement learning for reasoning (GLoRe, Llama 3), research agents that reason
+        over the web (Reka Research), in-context and continual RL, and generative models for
+        scientific discovery (GFlowNets).
       </p>
       <div className="research-grid">
         {papers.map((paper) => (

--- a/src/data/news.tsx
+++ b/src/data/news.tsx
@@ -43,16 +43,6 @@ export const newsItems: NewsItem[] = [
     ),
   },
   {
-    date: 'Mar 2025:',
-    icon: 'reka',
-    content: (
-      <>
-        Open-sourced <a href="https://reka.ai/news/introducing-reka-flash">Reka Flash 3</a>, a 21B
-        reasoning model trained from scratch.
-      </>
-    ),
-  },
-  {
     date: 'Oct 2024:',
     icon: 'reka',
     content: (


### PR DESCRIPTION
Correction per Sharath: he did not work on RL fine-tuning for Reka Flash 3. Removed that claim from the hero bio and the research statement, and dropped the Reka Flash 3 news item. Reka Research contributions (core development, SFT, SOTA on SimpleQA/Research-Eval) are unchanged. 11 tests pass.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_