### PR TITLE
Correct Reka AI start date to Sep 2023

### DIFF
--- a/src/data/news.tsx
+++ b/src/data/news.tsx
@@ -43,15 +43,6 @@ export const newsItems: NewsItem[] = [
     ),
   },
   {
-    date: 'Oct 2024:',
-    icon: 'reka',
-    content: (
-      <>
-        Joined <a href="https://www.reka.ai/">Reka AI</a> as a Member of Technical Staff.
-      </>
-    ),
-  },
-  {
     date: 'Sep 2024:',
     icon: 'neurips',
     content: (
@@ -153,6 +144,15 @@ export const newsItems: NewsItem[] = [
           Generalization to New Sequential Decision Making Tasks with In-Context Learning
         </a>
         .
+      </>
+    ),
+  },
+  {
+    date: 'Sep 2023:',
+    icon: 'reka',
+    content: (
+      <>
+        Joined <a href="https://www.reka.ai/">Reka AI</a> as a Member of Technical Staff.
       </>
     ),
   },


### PR DESCRIPTION
Per Sharath, he joined Reka AI in **Sep 2023** (not Oct 2024). Updated the news entry and moved it to its correct chronological slot in the reverse-ordered timeline. 11 tests pass.

https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf

---
_Generated by [Claude Code](https://claude.ai/code/session_017DZk6NkbHNGe4bCCKtuJtf)_